### PR TITLE
Fix integration bugs in 0.5.2: normalizer & external adapter resolution

### DIFF
--- a/.changeset/patch-0-5-2-integration-fixes.md
+++ b/.changeset/patch-0-5-2-integration-fixes.md
@@ -1,0 +1,11 @@
+---
+'@declaragent/cli': patch
+---
+
+Patch 0.5.2 — three integration fixes surfaced by the fleet-test run against 0.5.1.
+
+- **Bug 1 — `MessageNormalizer` missing from source deps.** `startAgentSources` now constructs a shared `createMessageNormalizer()` and threads it through `SourceDependencies.normalizer` when creating every adapter instance. Before this fix, `BaseSourceInstance.handleMessage()` saw `deps.normalizer === undefined`, logged `base-source.no-normalizer`, and silently ack'd + dropped every Kafka/NATS/SQS/AMQP/MQTT message — the event never reached the store. Built-in webhook/cron/file-watch adapters don't consume `deps.normalizer`, so the change is additive.
+
+- **Bug 2 — compiled `declaragent` binary couldn't resolve external adapters.** `bun build --compile` produces a single-file executable whose internal resolver intercepts bare module specifiers and has no on-disk `node_modules` to walk. A dynamically-imported adapter's `import '@declaragent/core'` failed with `Cannot find module`. The npm launcher at `packages/cli/bin/declaragent.js` now prefers `bun dist/index.js` whenever `bun` is on `PATH` and the JS dist is present — that path runs against the real filesystem, so external adapters load. The compiled binary remains the fallback when Bun isn't installed. Override with `DECLARAGENT_USE_BINARY=1` to force the old path.
+
+- **Bug 3 — new `prod-smoke-kafka.yml` CI workflow.** `npm install @declaragent/cli@latest @declaragent/source-kafka@latest`, scaffold a one-agent Kafka-source fleet, produce a JSON message on `smoke.input`, assert the event appears in `declaragent events list` within 30s. Triggers on push to main + a 6h cron + manual dispatch. The two pre-existing smoke workflows only exercised `declaragent --version`; this one is the first lane that exercises an adapter discovery + broker round-trip against the published tarballs.

--- a/.github/workflows/prod-smoke-kafka.yml
+++ b/.github/workflows/prod-smoke-kafka.yml
@@ -1,0 +1,141 @@
+name: prod smoke — kafka source end-to-end
+
+# Patch 0.5.2 (Bug 3 of PATCH_0_5_2_PLAN). Validates the path a real
+# user takes: `npm install @declaragent/cli @declaragent/source-kafka`,
+# scaffold, produce a message, assert the event lands in the store.
+# 0.5.0/0.5.1 shipped three integration bugs because no CI lane
+# cross-checked discovery + adapter wiring against the published
+# tarball path.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/cli/**'
+      - 'packages/core/**'
+      - 'packages/source-kafka/**'
+      - '.github/workflows/prod-smoke-kafka.yml'
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: prod-smoke-kafka-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: install + produce + assert
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Start Redpanda broker
+        run: |
+          set -euo pipefail
+          docker compose -f packages/source-kafka/test/fixtures/docker-compose.yml up -d
+          for i in $(seq 1 30); do
+            status="$(docker inspect -f '{{.State.Health.Status}}' declaragent-kafka-redpanda)"
+            [ "${status}" = "healthy" ] && break
+            sleep 2
+          done
+          docker inspect -f '{{.State.Health.Status}}' declaragent-kafka-redpanda | grep -q healthy || {
+            docker logs declaragent-kafka-redpanda >&2 || true
+            exit 1
+          }
+          docker exec declaragent-kafka-redpanda rpk topic create smoke.input --partitions 1 --replicas 1
+
+      - name: Stage project + scaffold agent
+        id: stage
+        run: |
+          set -euo pipefail
+          SCRATCH="${RUNNER_TEMP}/smoke"
+          mkdir -p "${SCRATCH}"
+          cd "${SCRATCH}"
+          npm init -y >/dev/null
+          # Latest published — exercise what a real user installs, not
+          # the workspace-linked build tree.
+          npm install --no-audit --no-fund \
+            @declaragent/cli@latest \
+            @declaragent/source-kafka@latest \
+            @declaragent/core@latest
+          cat > agent.yaml <<'YAML'
+          name: smoke
+          model: claude-haiku-4-5
+          systemPrompt: "Test agent; no LLM creds in CI so events stay pending."
+          skills: []
+          event-sources:
+            - ./event-sources.yaml
+          YAML
+          cat > event-sources.yaml <<'YAML'
+          - type: kafka
+            config:
+              id: smoke-consumer
+              transport:
+                brokers: [localhost:19092]
+                clientId: declaragent-smoke
+                consumerGroup: declaragent-smoke
+                topics: [smoke.input]
+                fromBeginning: true
+              routing:
+                format: json
+                kindSelector: { const: smoke.event }
+                targetSelector: { type: skill, name: noop }
+          YAML
+          echo "scratch=${SCRATCH}" >> "${GITHUB_OUTPUT}"
+
+      - name: Start declaragent up (bun + JS dist, working around Bug 2)
+        working-directory: ${{ steps.stage.outputs.scratch }}
+        run: |
+          set -euo pipefail
+          # Published tarball ships a compiled binary whose resolver
+          # can't locate `@declaragent/core` when it dynamically imports
+          # an external adapter's dist/index.js. 0.5.2's launcher picks
+          # this path automatically; invoking the JS dist directly
+          # documents the contract CI is validating.
+          bun node_modules/@declaragent/cli/dist/index.js up -f agent.yaml &
+          echo $! > up.pid
+          sleep 5
+
+      - name: Produce a test message
+        run: |
+          set -euo pipefail
+          printf '{"id":"smoke-1","payload":"hello"}\n' | \
+            docker exec -i declaragent-kafka-redpanda rpk topic produce smoke.input
+
+      - name: Assert the event landed in the store
+        working-directory: ${{ steps.stage.outputs.scratch }}
+        run: |
+          set -euo pipefail
+          # Poll up to 30s for the event to appear. No LLM creds ⇒
+          # outcome stays `pending`, which is exactly what we assert:
+          # the event reached the store via the normalizer.
+          for i in $(seq 1 30); do
+            output="$(bun node_modules/@declaragent/cli/dist/index.js events list 2>/dev/null || true)"
+            if echo "${output}" | grep -q 'smoke.event'; then
+              echo "✓ event surfaced:"
+              echo "${output}"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "✗ event never surfaced" >&2
+          bun node_modules/@declaragent/cli/dist/index.js events list >&2 || true
+          exit 1
+
+      - name: Tear down
+        if: always()
+        working-directory: ${{ steps.stage.outputs.scratch }}
+        run: |
+          set +e
+          [ -f up.pid ] && kill "$(cat up.pid)" 2>/dev/null
+          docker compose -f "${GITHUB_WORKSPACE}/packages/source-kafka/test/fixtures/docker-compose.yml" down -v

--- a/packages/cli/bin/declaragent.js
+++ b/packages/cli/bin/declaragent.js
@@ -8,15 +8,77 @@
 // If the binary isn't present (DECLARAGENT_NO_POSTINSTALL was set, a
 // sandboxed install blocked the network, etc.), we print a one-line
 // recovery hint and exit non-zero so CI picks the problem up.
+//
+// 0.5.2 update (Bug 2 of PATCH_0_5_2_PLAN): the compiled binary's
+// dynamic-import resolver can't load external event-source adapters
+// (`@declaragent/source-kafka`, etc.) because `bun build --compile`
+// intercepts bare specifiers and has no on-disk `node_modules` to
+// walk. When `bun` is on PATH + the CLI's `dist/index.js` is
+// resolvable, prefer `bun dist/index.js`. Commands that don't touch
+// external adapters keep working on the binary fallback.
 
 import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { existsSync, statSync } from 'node:fs';
+import { delimiter, dirname, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+// The compiled binary lives next to this launcher, dropped by
+// `postinstall.js`.
 const binaryPath = resolve(__dirname, 'declaragent-binary', 'declaragent');
+
+// The JS entrypoint ships in the same package tarball, one directory up.
+// When `bun` is available we route through it so dynamic imports of
+// external adapters resolve against the real filesystem.
+const distEntry = resolve(__dirname, '..', 'dist', 'index.js');
+
+function findOnPath(cmd) {
+  const pathEnv = process.env.PATH;
+  if (!pathEnv) return null;
+  const suffixes = process.platform === 'win32' ? ['.exe', '.cmd', '.bat', ''] : [''];
+  for (const dir of pathEnv.split(delimiter)) {
+    if (!dir) continue;
+    for (const suffix of suffixes) {
+      const candidate = dir + sep + cmd + suffix;
+      try {
+        if (existsSync(candidate) && statSync(candidate).isFile()) return candidate;
+      } catch {
+        // ignore and keep searching
+      }
+    }
+  }
+  return null;
+}
+
+function exitWith(result) {
+  if (result.error) {
+    process.stderr.write(`declaragent: failed to launch: ${result.error.message}\n`);
+    process.exit(1);
+  }
+  // Mirror the child's signal if it died from one; otherwise forward
+  // its exit code so scripts that wrap declaragent see the real result.
+  if (typeof result.signal === 'string' && result.signal.length > 0) {
+    process.kill(process.pid, result.signal);
+    process.exit(1);
+  }
+  process.exit(result.status ?? 0);
+}
+
+// Prefer Bun + dist JS when both are available. Users can opt out by
+// setting DECLARAGENT_USE_BINARY=1 — useful when debugging the compiled
+// binary, and a safety valve if the Bun path ever regresses.
+const preferBinary = process.env.DECLARAGENT_USE_BINARY === '1';
+const bunPath = preferBinary ? null : findOnPath('bun');
+const canUseBun = bunPath !== null && existsSync(distEntry);
+
+if (canUseBun) {
+  const result = spawnSync(bunPath, [distEntry, ...process.argv.slice(2)], {
+    stdio: 'inherit',
+    env: process.env,
+  });
+  exitWith(result);
+}
 
 if (!existsSync(binaryPath)) {
   const postinstallPath = resolve(__dirname, 'postinstall.js');
@@ -32,17 +94,4 @@ const result = spawnSync(binaryPath, process.argv.slice(2), {
   env: process.env,
 });
 
-if (result.error) {
-  process.stderr.write(`declaragent: failed to launch binary: ${result.error.message}\n`);
-  process.exit(1);
-}
-
-// Mirror the child's exit signal if it died from one; otherwise
-// forward its exit code so scripts that wrap declaragent see the real
-// result.
-if (typeof result.signal === 'string' && result.signal.length > 0) {
-  process.kill(process.pid, result.signal);
-  process.exit(1);
-}
-
-process.exit(result.status ?? 0);
+exitWith(result);

--- a/packages/cli/bin/declaragent.test.ts
+++ b/packages/cli/bin/declaragent.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// The npm launcher. 0.5.2 (Bug 2 of PATCH_0_5_2_PLAN) adds a Bun path
+// in front of the compiled-binary path so external adapters can load.
+// We copy the launcher into a sandbox so `binaryPath` resolves to a
+// sandboxed location and the real compiled binary in the repo (if any)
+// isn't touched.
+
+const realLauncherPath = fileURLToPath(new URL('./declaragent.js', import.meta.url));
+
+describe('declaragent npm launcher', () => {
+  let sandbox: string;
+  let launcherPath: string;
+  let fakeBinDir: string;
+  let binaryDir: string;
+  let distDir: string;
+
+  beforeEach(() => {
+    sandbox = mkdtempSync(join(tmpdir(), 'declara-launcher-'));
+
+    // Mirror the real package layout the launcher assumes.
+    //   sandbox/bin/declaragent.js      ← launcher (copy of real one)
+    //   sandbox/bin/declaragent-binary/ ← the compiled binary dir
+    //   sandbox/dist/index.js           ← the JS entrypoint
+    const pkgBinDir = join(sandbox, 'bin');
+    mkdirSync(pkgBinDir, { recursive: true });
+    launcherPath = join(pkgBinDir, 'declaragent.js');
+    copyFileSync(realLauncherPath, launcherPath);
+
+    binaryDir = join(pkgBinDir, 'declaragent-binary');
+    distDir = join(sandbox, 'dist');
+    mkdirSync(distDir, { recursive: true });
+
+    fakeBinDir = join(sandbox, 'fake-path');
+    mkdirSync(fakeBinDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  function writeShim(dir: string, name: string, body: string): string {
+    const shim = join(dir, name);
+    writeFileSync(shim, body);
+    chmodSync(shim, 0o755);
+    return shim;
+  }
+
+  test('prefers bun + dist/index.js when bun is on PATH', () => {
+    writeShim(fakeBinDir, 'bun', '#!/bin/sh\necho "FAKE_BUN" "$@"\nexit 0\n');
+    // A non-empty dist entry is enough — existsSync() is the gate.
+    writeFileSync(join(distDir, 'index.js'), '// placeholder\n');
+
+    const result = spawnSync(process.execPath, [launcherPath, '--version'], {
+      env: { ...process.env, PATH: fakeBinDir, DECLARAGENT_USE_BINARY: '' },
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('FAKE_BUN');
+    expect(result.stdout).toContain('index.js');
+    expect(result.stdout).toContain('--version');
+  });
+
+  test('falls back to the binary when DECLARAGENT_USE_BINARY=1', () => {
+    writeShim(fakeBinDir, 'bun', '#!/bin/sh\necho "FAKE_BUN" "$@"\nexit 0\n');
+    writeFileSync(join(distDir, 'index.js'), '// placeholder\n');
+
+    mkdirSync(binaryDir, { recursive: true });
+    writeShim(binaryDir, 'declaragent', '#!/bin/sh\necho "FAKE_BINARY" "$@"\nexit 0\n');
+
+    const result = spawnSync(process.execPath, [launcherPath, 'ping'], {
+      env: { ...process.env, PATH: fakeBinDir, DECLARAGENT_USE_BINARY: '1' },
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('FAKE_BINARY');
+    expect(result.stdout).not.toContain('FAKE_BUN');
+  });
+
+  test('falls back to the binary when bun is NOT on PATH', () => {
+    // No bun shim. Launcher must pick the binary fallback.
+    mkdirSync(binaryDir, { recursive: true });
+    writeShim(binaryDir, 'declaragent', '#!/bin/sh\necho "FAKE_BINARY" "$@"\nexit 0\n');
+
+    const result = spawnSync(process.execPath, [launcherPath, 'ping'], {
+      env: { ...process.env, PATH: fakeBinDir },
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('FAKE_BINARY');
+  });
+
+  test('falls back to the binary when dist/index.js is missing even with bun on PATH', () => {
+    // Regression guard: globally-installed CLI ships the compiled
+    // binary but the JS dist is also present in the tarball. Running
+    // the launcher out of a build where dist was pruned must still
+    // exec the binary rather than crashing.
+    writeShim(fakeBinDir, 'bun', '#!/bin/sh\necho "FAKE_BUN" "$@"\nexit 0\n');
+    // intentionally no dist/index.js
+    mkdirSync(binaryDir, { recursive: true });
+    writeShim(binaryDir, 'declaragent', '#!/bin/sh\necho "FAKE_BINARY" "$@"\nexit 0\n');
+
+    const result = spawnSync(process.execPath, [launcherPath, 'ping'], {
+      env: { ...process.env, PATH: fakeBinDir },
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('FAKE_BINARY');
+    expect(result.stdout).not.toContain('FAKE_BUN');
+  });
+
+  test('prints a recovery hint and exits 1 when neither bun-dist nor binary are present', () => {
+    // No bun, no binary — the pre-0.5.2 behavior is preserved.
+    const result = spawnSync(process.execPath, [launcherPath, 'ping'], {
+      env: { ...process.env, PATH: fakeBinDir },
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('binary not found');
+  });
+});

--- a/packages/cli/src/run-agent-sources.test.ts
+++ b/packages/cli/src/run-agent-sources.test.ts
@@ -280,6 +280,83 @@ describe('startAgentSources — external adapter discovery', () => {
     await res.stop();
   });
 
+  test('passes a MessageNormalizer through SourceDependencies.normalizer', async () => {
+    // Regression for 0.5.1: SourceDependencies was built without a
+    // `normalizer`, so BaseSourceInstance.handleMessage() logged
+    // `base-source.no-normalizer` and silently ack'd+dropped every
+    // message. The fixture adapter captures the deps it was handed so
+    // we can assert `normalizer` is defined.
+    const capturedDeps: Array<Record<string, unknown>> = [];
+    (
+      globalThis as { __declaragent_capture_deps__?: typeof capturedDeps }
+    ).__declaragent_capture_deps__ = capturedDeps;
+
+    const pkgDir = join(agentDir, 'node_modules', '@declaragent', 'source-capture');
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(
+      join(pkgDir, 'package.json'),
+      JSON.stringify({
+        name: '@declaragent/source-capture',
+        version: '0.0.1',
+        main: './index.js',
+        declaragent: {
+          kind: 'event-source-adapter',
+          type: 'capture',
+          agent_compat: '>=0.0.1',
+        },
+      }),
+    );
+    writeFileSync(
+      join(pkgDir, 'index.js'),
+      `export default {
+  type: 'capture',
+  validateConfig(config) {
+    if (!config || typeof config !== 'object') throw new Error('config required');
+    if (typeof config.id !== 'string') throw new Error('id required');
+    if (!config.target || typeof config.target !== 'object') throw new Error('target required');
+  },
+  async create(config, deps) {
+    globalThis.__declaragent_capture_deps__?.push(deps);
+    return {
+      id: config.id,
+      type: 'capture',
+      async start() {},
+      async stop() {},
+      async pause() {},
+      async resume() {},
+      async health() { return { status: 'healthy' }; },
+      metrics() { return { eventsPublished: 0, errors: 0, lastEventAt: null, lastStatus: null }; },
+    };
+  },
+};
+`,
+    );
+
+    writeFileSync(
+      sourcesPath,
+      `- type: capture
+  config:
+    id: cap
+    target:
+      type: skill
+      name: s
+`,
+    );
+
+    const res = await startAgentSources({ configPath: sourcesPath, agentDir, storePath });
+    expect(res.started).toHaveLength(1);
+    expect(capturedDeps).toHaveLength(1);
+    const deps = capturedDeps[0];
+    expect(deps).toBeDefined();
+    expect(deps?.normalizer).toBeDefined();
+    // Shape-check: `createMessageNormalizer()` returns `{ normalize(raw, routing, ctx) }`.
+    expect(typeof (deps?.normalizer as { normalize?: unknown })?.normalize).toBe('function');
+    await res.stop();
+
+    (globalThis as { __declaragent_capture_deps__?: unknown }).__declaragent_capture_deps__ =
+      undefined;
+  });
+
   test('two packages claiming the same type throw (strict duplicate handling)', async () => {
     // Both packages claim type=dup. The core discovery's duplicate
     // check fires and throws an AdapterDiscoveryError — user-visible.

--- a/packages/cli/src/run-agent-sources.ts
+++ b/packages/cli/src/run-agent-sources.ts
@@ -38,6 +38,7 @@ import {
   createEventBus,
   createEventStore,
   createFileWatchAdapter,
+  createMessageNormalizer,
   createWebhookAdapter,
   discoverAdapters,
   validateEventSourcesConfig,
@@ -265,6 +266,15 @@ export async function startAgentSources(
   const instances: EventSourceInstance[] = [];
   const started: Array<{ type: string; id: string; summary: string }> = [];
 
+  // Shared across every adapter. External broker adapters (kafka, nats,
+  // sqs, …) route raw broker payloads through `BaseSourceInstance`,
+  // which requires `deps.normalizer` to convert bytes → `AgentEvent`.
+  // Without one, `base-source.no-normalizer` fires and the message is
+  // ack'd and dropped — the exact bug that slipped through 0.5.1.
+  // Built-in webhook/cron/file-watch adapters don't read this field;
+  // they construct `AgentEvent`s themselves.
+  const normalizer = createMessageNormalizer({ logger });
+
   for (const src of report.sources) {
     const adapter = adapters[src.type];
     if (adapter === undefined) {
@@ -280,6 +290,7 @@ export async function startAgentSources(
         bus,
         logger,
         configDir: configDir(),
+        normalizer,
       });
       await inst.start();
       instances.push(inst);


### PR DESCRIPTION
## Summary

This PR fixes three critical integration bugs discovered in 0.5.1 that prevented external event-source adapters (Kafka, NATS, SQS, etc.) from functioning in production:

1. **Missing `MessageNormalizer` in source dependencies** — external adapters couldn't normalize broker messages
2. **Compiled binary couldn't resolve external adapters** — `bun build --compile` breaks dynamic imports
3. **No CI validation of the published tarball path** — integration bugs weren't caught before release

## Key Changes

- **`packages/cli/src/run-agent-sources.ts`**: Create a shared `MessageNormalizer` instance and pass it through `SourceDependencies.normalizer` when instantiating all adapters. External broker adapters (Kafka, NATS, SQS, AMQP, MQTT) require this to convert raw payloads to `AgentEvent`s; without it, messages were silently ack'd and dropped.

- **`packages/cli/bin/declaragent.js`**: Enhanced npm launcher to prefer `bun dist/index.js` over the compiled binary when `bun` is available on `PATH` and `dist/index.js` exists. This works around the compiled binary's inability to resolve dynamically-imported external adapters. Falls back to the binary for commands that don't touch external adapters, and respects `DECLARAGENT_USE_BINARY=1` to opt out.

- **`.github/workflows/prod-smoke-kafka.yml`** (new): End-to-end smoke test that validates the real user path: install published packages, scaffold an agent, produce a Kafka message, and assert it lands in the store. Runs on every push to `main` and every 6 hours to catch regressions.

- **`packages/cli/bin/declaragent.test.ts`** (new): Unit tests for the launcher's fallback logic, covering bun-present, bun-absent, binary-present, and error cases.

- **`packages/cli/src/run-agent-sources.test.ts`**: Added regression test verifying that `SourceDependencies.normalizer` is defined and callable when adapters are instantiated.

- **`.changeset/patch-0-5-2-integration-fixes.md`**: Changelog documenting all three bugs and their fixes.

## Implementation Details

- The launcher uses `findOnPath()` to locate `bun` on `PATH` and checks `existsSync(distEntry)` before routing through it, ensuring graceful fallback to the binary if either is unavailable.
- The `exitWith()` helper consolidates error handling and signal mirroring for both code paths (bun and binary).
- The smoke test uses a real Redpanda broker and validates the full event pipeline: produce → consume → normalize → store.
- All changes are backward-compatible; built-in adapters (webhook, cron, file-watch) don't consume `deps.normalizer`.

https://claude.ai/code/session_01Kb4L9XBayfoc1qm5ybxQYA