### PR TITLE
feat(core,cli): control socket on up daemon + dlq.requeue helper (#6)

### DIFF
--- a/packages/cli/src/ps-cli.ts
+++ b/packages/cli/src/ps-cli.ts
@@ -1,14 +1,27 @@
 /**
  * `declaragent ps` — list agents currently up.
  *
- * Mirrors `docker compose ps`: reads the up-state snapshot, confirms
- * the owning pid is still alive (reaps stale state otherwise), and
- * prints a human-readable table. Exit 0 with "nothing up" when
- * nothing is running — scripts can test the exit code.
+ * Primary data source (0.6.x): the per-agent control socket at
+ * `~/.declaragent/<agent-id>/control.sock`. Each agent's socket
+ * responds to `status` with a fresh pid/uptime/sources/lastEventAt
+ * tuple — so `ps` reflects the daemon's real state rather than a
+ * snapshot `up` wrote once at boot.
  *
- * @since 0.4.1
+ * Fallback: the `up-state.json` snapshot. This is still the only way
+ * to learn "which agents exist" in the first place (one state file
+ * catalogs every agent the up-process hosts), and it's the sole path
+ * when the socket has been removed or the daemon crashed without
+ * cleaning up.
+ *
+ * @since 0.4.1 / rewired for control-socket 0.6.x
  */
 
+import {
+  type ControlSocketResponse,
+  type ControlSocketStatus,
+  connectControlSocket,
+  controlSocketPath,
+} from '@declaragent/core';
 import type { UpAgentSummary } from './up-lifecycle.js';
 import { reapStaleState } from './up-lifecycle.js';
 
@@ -20,6 +33,8 @@ const STDIO_IO: PsIO = { out: (s) => process.stdout.write(s) };
 
 export interface PsDeps {
   io?: PsIO;
+  /** Override the socket-path resolver (tests). */
+  resolveSocket?: (agentId: string) => string;
 }
 
 export async function ps(deps: PsDeps = {}): Promise<number> {
@@ -34,15 +49,75 @@ export async function ps(deps: PsDeps = {}): Promise<number> {
   io.out(`up since ${upSince} — pid ${state.pid}, manifest ${state.manifestPath}\n\n`);
 
   for (const agent of state.agents) {
-    io.out(formatAgent(agent));
+    const resolveSocket = deps.resolveSocket ?? ((id) => controlSocketPath(id));
+    // Try the live socket first; fall through to the state-file
+    // snapshot when it's unreachable (daemon crashed, stale state,
+    // or the agent predates 0.6.x).
+    const liveStatus = await tryFetchStatus(resolveSocket(agent.id));
+    if (liveStatus) {
+      io.out(formatAgentLive(agent, liveStatus));
+    } else {
+      io.out(formatAgentSnapshot(agent));
+    }
   }
 
   return 0;
 }
 
-function formatAgent(agent: UpAgentSummary): string {
+/**
+ * Best-effort probe of the agent's control socket. Returns `null` when
+ * the socket is absent, the connect hangs past our short timeout, or
+ * the `status` op errors. Callers fall back to the on-disk snapshot.
+ */
+async function tryFetchStatus(socketPath: string): Promise<ControlSocketStatus | null> {
+  let client: Awaited<ReturnType<typeof connectControlSocket>> | null = null;
+  try {
+    client = await connectControlSocket(socketPath, { timeoutMs: 500 });
+    const resp: ControlSocketResponse = await client.call({ id: 'ps-status', op: 'status' });
+    if (resp.op === 'status' && 'result' in resp) {
+      return resp.result;
+    }
+    return null;
+  } catch {
+    return null;
+  } finally {
+    try {
+      client?.close();
+    } catch {
+      // ignore
+    }
+  }
+}
+
+function formatAgentLive(agent: UpAgentSummary, status: ControlSocketStatus): string {
   const lines: string[] = [];
-  lines.push(`  ${agent.id}`);
+  lines.push(`  ${agent.id}  (live via control socket)`);
+  lines.push(`    path: ${agent.path}`);
+  lines.push(`    pid: ${status.pid}`);
+  const uptime = humanizeMs(status.uptimeMs);
+  lines.push(`    uptime: ${uptime}`);
+  if (status.sources.length === 0) {
+    lines.push('    sources: (skill-only)');
+  } else {
+    lines.push(`    sources: ${status.sources.length}`);
+    for (const s of status.sources) {
+      // Prefer the snapshot's richer summary line when it exists; fall
+      // back to `type/id` from the live socket.
+      const snapshotMatch = agent.sources.find((x) => x.id === s.id);
+      lines.push(`      • ${snapshotMatch ? snapshotMatch.summary : `${s.type} (${s.id})`}`);
+    }
+  }
+  if (status.lastEventAt !== undefined) {
+    lines.push(`    last event: ${relativeTime(new Date(status.lastEventAt))}`);
+  } else {
+    lines.push('    last event: (none yet)');
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function formatAgentSnapshot(agent: UpAgentSummary): string {
+  const lines: string[] = [];
+  lines.push(`  ${agent.id}  (snapshot)`);
   lines.push(`    path: ${agent.path}`);
   if (agent.sources.length === 0) {
     lines.push('    sources: (skill-only)');
@@ -66,4 +141,16 @@ function relativeTime(start: Date): string {
   if (hours < 24) return `${hours}h ago`;
   const days = Math.floor(hours / 24);
   return `${days}d ago`;
+}
+
+function humanizeMs(ms: number): string {
+  if (ms < 0) return '0s';
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ${seconds % 60}s`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ${minutes % 60}m`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ${hours % 24}h`;
 }

--- a/packages/cli/src/up-cli.ts
+++ b/packages/cli/src/up-cli.ts
@@ -33,7 +33,11 @@ import {
   type AgentSpec,
   CircuitBreaker,
   type CircuitBreakerTransitionEvent,
+  type ControlSocketContext,
+  type ControlSocketServer,
+  type EventBus,
   type EventDispatcher,
+  type EventStore,
   type LLMProvider,
   type LoadedAgent,
   type Logger,
@@ -53,6 +57,7 @@ import {
   loadAgent,
   loadFleet,
   skillExtension,
+  startControlSocket,
   startPrometheusExporter,
   withProviderRateLimit,
 } from '@declaragent/core';
@@ -249,6 +254,21 @@ interface RunningAgent {
    * source; skill-only / creds-missing agents keep this undefined.
    */
   detachDispatcher?: () => void;
+  /**
+   * Control socket bound at `~/.declaragent/<agent-id>/control.sock`.
+   * Speaks the `ping`/`status`/`dlq.requeue`/`reload`/`shutdown` ops
+   * defined in {@link startControlSocket}. Closed during `stopAll`.
+   * @since 0.6.x
+   */
+  controlSocket?: ControlSocketServer;
+  /**
+   * ms-epoch of the last event the agent's bus observed. Updated by a
+   * wildcard subscriber installed when the socket is bound so `status`
+   * can report `lastEventAt` without re-reading the event store.
+   */
+  lastEventAt?: number;
+  /** Unsubscribe the lastEventAt-tracker subscriber on shutdown. */
+  detachLastEventTracker?: () => void;
 }
 
 /**
@@ -606,7 +626,7 @@ async function bringUp(
     });
   }
 
-  return {
+  const running: RunningAgent = {
     summary: { id: agentId, path: agentDir, sources: summary },
     sources,
     logger,
@@ -615,6 +635,131 @@ async function bringUp(
     ...(plugins && { plugins }),
     ...(detachDispatcher !== undefined && { detachDispatcher }),
   };
+
+  // Bind the control socket (§3 item #6 of the Enterprise Production
+  // Plan). One socket per agent at `~/.declaragent/<id>/control.sock`;
+  // speaks the ping/status/dlq.requeue/reload/shutdown ops.
+  //
+  // Failure here is non-fatal — we'd rather let `up` run without a
+  // socket than refuse to start. A `ps` fall-through still works via
+  // the `up-state.json` snapshot.
+  try {
+    const socket = await bindControlSocket({
+      agentId,
+      running,
+      ...(sources.bus && { bus: sources.bus }),
+      ...(sources.eventStore && { eventStore: sources.eventStore }),
+      logger,
+    });
+    if (socket) {
+      running.controlSocket = socket.server;
+      if (socket.detachLastEventTracker) {
+        running.detachLastEventTracker = socket.detachLastEventTracker;
+      }
+      io.out(`  ${agentId}: control socket ${socket.server.socketPath}\n`);
+    }
+  } catch (err) {
+    io.err(
+      `⚠ ${agentId}: control socket failed to bind — ${err instanceof Error ? err.message : String(err)}. Continuing without it.\n`,
+    );
+  }
+
+  return running;
+}
+
+/**
+ * Bind the per-agent control socket. Returns `null` when binding
+ * silently opts out. The returned server is stored on `RunningAgent`
+ * and closed during `stopAll`.
+ *
+ * Why a helper: `bringUp` already has enough going on, and the
+ * closure over `running` / `lastEventAt` is awkward inline.
+ *
+ * @since 0.6.x
+ */
+async function bindControlSocket(opts: {
+  agentId: string;
+  running: RunningAgent;
+  bus?: EventBus;
+  eventStore?: EventStore;
+  logger: AgentLogger;
+}): Promise<{
+  server: ControlSocketServer;
+  detachLastEventTracker?: () => void;
+} | null> {
+  const { agentId, running, bus, eventStore, logger } = opts;
+  const startedAt = Date.now();
+
+  // Install the lastEventAt tracker only when a bus exists. Skill-only
+  // agents never see events so the field stays `undefined`.
+  let detachLastEventTracker: (() => void) | undefined;
+  if (bus) {
+    detachLastEventTracker = bus.subscribe('*', () => {
+      running.lastEventAt = Date.now();
+    });
+  }
+
+  const context: ControlSocketContext = {
+    agentId,
+    pid: process.pid,
+    startedAt,
+    sources: () => {
+      // Map the started summary back to id/type pairs. We don't have
+      // direct refs to `EventSourceInstance` objects here (sources.ts
+      // doesn't surface them), and the control socket only needs the
+      // id+type so the stub below is type-compatible with what the
+      // `status` op extracts.
+      return running.sources.started.map(
+        (s) =>
+          ({
+            id: s.id,
+            type: s.type,
+            start: async () => {},
+            stop: async () => {},
+            pause: async () => {},
+            resume: async () => {},
+            health: async () => ({ status: 'ok' as const }),
+            metrics: () => ({ eventsPublished: 0, lastEventAt: null }),
+          }) as unknown as import('@declaragent/core').EventSourceInstance,
+      );
+    },
+    lastEventAt: () => running.lastEventAt,
+    ...(bus && { bus }),
+    ...(eventStore && { store: eventStore }),
+    reload: () => ({
+      reloaded: false,
+      reason: 'unsupported',
+      message:
+        'hot reload of sources is not implemented; restart `declaragent up` to apply changes',
+    }),
+    // shutdown is wired at the top-level `runForeground` so it reaches
+    // the whole up process, not just one agent. We leave it undefined
+    // here — a later PR (#3 DLQ requeue verb) can add a per-agent
+    // shutdown flag if needed.
+    logger: agentLoggerToCoreLogger(logger),
+  };
+
+  try {
+    const server = await startControlSocket({ context });
+    const result: {
+      server: ControlSocketServer;
+      detachLastEventTracker?: () => void;
+    } = { server };
+    if (detachLastEventTracker) {
+      result.detachLastEventTracker = detachLastEventTracker;
+    }
+    return result;
+  } catch (err) {
+    // Cleanup the subscriber if we installed one before the bind failed.
+    if (detachLastEventTracker) {
+      try {
+        detachLastEventTracker();
+      } catch {
+        // ignore
+      }
+    }
+    throw err;
+  }
 }
 
 /**
@@ -836,6 +981,18 @@ function printBanner(io: UpIO, agent: RunningAgent): void {
 
 async function stopAll(running: RunningAgent[]): Promise<void> {
   for (const r of running) {
+    // Close the control socket first so operators sending `shutdown`
+    // don't race an already-stopping daemon.
+    try {
+      r.detachLastEventTracker?.();
+    } catch {
+      // swallow — best-effort
+    }
+    try {
+      await r.controlSocket?.close();
+    } catch {
+      // swallow — best-effort shutdown
+    }
     try {
       r.detachDispatcher?.();
     } catch {

--- a/packages/cli/src/up-control-socket.test.ts
+++ b/packages/cli/src/up-control-socket.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Integration test for the control socket bound by `declaragent up`
+ * (§3 item #6 of the Enterprise Production Plan).
+ *
+ * Spins up the real `up` loop in-process with a stubbed source, then
+ * connects a control-socket client and exercises all five ops:
+ *   - `ping`
+ *   - `status`
+ *   - `dlq.requeue`
+ *   - `reload`
+ *   - `shutdown`
+ *
+ * The agent boot path is heavily reused from `up-cli.test.ts`; the
+ * point of this file is specifically to prove that the socket is
+ * bound at the same lifecycle stage as `/metrics` and that operators
+ * can reach every op over it.
+ *
+ * @since 0.6.x
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { connectControlSocket, controlSocketPath } from '@declaragent/core';
+import type {
+  StartAgentSourcesOptions,
+  StartAgentSourcesResult,
+  startAgentSources,
+} from './run-agent-sources.js';
+import { up } from './up-cli.js';
+
+const AGENT_YAML = `
+name: ctrl-sock-agent
+systemPrompt: |
+  You are a test agent.
+skills: []
+`;
+
+const EVENT_SOURCES = `- type: cron
+  config:
+    id: every-minute
+    schedule: "* * * * *"
+    target: { type: skill, name: say-hi }
+`;
+
+type StartSourcesFn = typeof startAgentSources;
+
+function stubSources(started: StartAgentSourcesResult['started'] = []): StartSourcesFn {
+  return async (_opts: StartAgentSourcesOptions) => {
+    return {
+      started,
+      unknownTypes: [],
+      validationErrors: [],
+      stop: async () => {},
+    };
+  };
+}
+
+function captureIo(): {
+  out: string[];
+  err: string[];
+  io: { out: (s: string) => void; err: (s: string) => void };
+} {
+  const out: string[] = [];
+  const err: string[] = [];
+  return { out, err, io: { out: (s) => out.push(s), err: (s) => err.push(s) } };
+}
+
+describe('up control socket — end-to-end', () => {
+  let dir: string;
+  let homeOverride: string | undefined;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'declara-up-ctrl-sock-'));
+    writeFileSync(join(dir, 'agent.yaml'), AGENT_YAML);
+    writeFileSync(join(dir, 'event-sources.yaml'), EVENT_SOURCES);
+    homeOverride = process.env.HOME;
+    process.env.HOME = dir;
+  });
+  afterEach(() => {
+    if (homeOverride !== undefined) process.env.HOME = homeOverride;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('up binds a control socket reachable from a client that answers all 5 ops', async () => {
+    const agentId = 'ctrl-sock-agent';
+    const expectedPath = controlSocketPath(agentId, dir);
+
+    // Drive the up loop. We use a "deferred shutdown" pattern so the
+    // loop stays alive long enough for us to connect + call, then
+    // resolves cleanly when we're done.
+    let shutdownHook: (() => Promise<void>) | null = null;
+    const upReady = new Promise<void>((resolve) => {
+      // Installer sets the hook, signals readiness, and returns the
+      // unregister fn. The up loop blocks until `shutdownHook()` is
+      // invoked below.
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const installer = (onShutdown: () => Promise<void>): (() => void) => {
+        shutdownHook = onShutdown;
+        resolve();
+        return () => {};
+      };
+      // Kick off up in the background.
+      const cap = captureIo();
+      void up(
+        {},
+        {
+          io: cap.io,
+          cwd: dir,
+          startSources: stubSources([
+            { type: 'cron', id: 'every-minute', summary: 'cron "* * * * *"' },
+          ]),
+          installSignals: installer,
+        },
+      );
+    });
+
+    await upReady;
+
+    // Poll for the socket file to appear — binding is async.
+    const deadline = Date.now() + 2000;
+    while (Date.now() < deadline) {
+      if (existsSync(expectedPath)) break;
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    expect(existsSync(expectedPath)).toBe(true);
+
+    const client = await connectControlSocket(expectedPath, { timeoutMs: 2000 });
+    try {
+      // 1. ping
+      const ping = await client.call({ id: 'p1', op: 'ping' });
+      expect(ping.op).toBe('ping');
+      if (ping.op === 'ping' && 'result' in ping) {
+        expect(ping.result.pong).toBe(true);
+      }
+
+      // 2. status
+      const status = await client.call({ id: 's1', op: 'status' });
+      expect(status.op).toBe('status');
+      if (status.op === 'status' && 'result' in status) {
+        expect(status.result.pid).toBe(process.pid);
+        expect(status.result.agentId).toBe(agentId);
+        expect(status.result.sources).toEqual([{ id: 'every-minute', type: 'cron' }]);
+        expect(status.result.uptimeMs).toBeGreaterThanOrEqual(0);
+      }
+
+      // 3. reload — skills-didn't-change → the wired handler currently
+      // returns `unsupported` for the single-agent up loop.
+      const reload = await client.call({ id: 'r1', op: 'reload' });
+      expect(reload.op).toBe('reload');
+      if (reload.op === 'reload' && 'result' in reload) {
+        expect(reload.result.reloaded).toBe(false);
+        expect(reload.result.reason).toBe('unsupported');
+      }
+
+      // 4. dlq.requeue — no event in the DLQ yet, so we expect a
+      // typed error (ENOBUS when the skill-only test has no bus, or
+      // `dlq-miss` when a bus is present). The stub source config
+      // above creates a cron adapter which does produce a bus, so
+      // we should get the `dlq-miss` path.
+      const requeue = await client.call({
+        id: 'rq1',
+        op: 'dlq.requeue',
+        params: { eventId: 'never-existed' },
+      });
+      expect(requeue.op).toBe('dlq.requeue');
+      if (requeue.op === 'dlq.requeue') {
+        if ('result' in requeue) {
+          expect(requeue.result.ok).toBe(false);
+        } else {
+          // Also acceptable: ENOBUS when no bus is wired.
+          expect(['ENOBUS', 'EHANDLER']).toContain(requeue.error.code);
+        }
+      }
+
+      // 5. shutdown — acks but the shutdown hook isn't wired per-agent,
+      // so the op reports ok=true and the up loop stays alive; we tear
+      // it down via the installer hook below.
+      const shutdown = await client.call({ id: 'sd1', op: 'shutdown' });
+      expect(shutdown.op).toBe('shutdown');
+      if (shutdown.op === 'shutdown' && 'result' in shutdown) {
+        expect(shutdown.result.ok).toBe(true);
+      }
+    } finally {
+      client.close();
+      // Trip the up loop's shutdown so the test process exits cleanly.
+      if (shutdownHook) {
+        await (shutdownHook as () => Promise<void>)();
+      }
+    }
+
+    // After shutdown, the socket file should be gone (auto-clean on
+    // process exit invariant from the spec).
+    const postDeadline = Date.now() + 2000;
+    while (Date.now() < postDeadline) {
+      if (!existsSync(expectedPath)) break;
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    expect(existsSync(expectedPath)).toBe(false);
+  });
+
+  test('a stale socket from a prior crash does not wedge the next up start', async () => {
+    // Pre-create a file at the socket path to simulate a stale socket
+    // left behind by a hard-killed `up`.
+    const agentId = 'ctrl-sock-agent';
+    const expectedPath = controlSocketPath(agentId, dir);
+    // Make sure parent dir exists
+    const { mkdirSync } = await import('node:fs');
+    mkdirSync(join(dir, '.declaragent', agentId), { recursive: true });
+    writeFileSync(expectedPath, 'stale');
+    expect(existsSync(expectedPath)).toBe(true);
+
+    let shutdownHook: (() => Promise<void>) | null = null;
+    const ready = new Promise<void>((resolve) => {
+      const installer = (onShutdown: () => Promise<void>): (() => void) => {
+        shutdownHook = onShutdown;
+        resolve();
+        return () => {};
+      };
+      const cap = captureIo();
+      void up(
+        {},
+        {
+          io: cap.io,
+          cwd: dir,
+          startSources: stubSources([
+            { type: 'cron', id: 'every-minute', summary: 'cron "* * * * *"' },
+          ]),
+          installSignals: installer,
+        },
+      );
+    });
+    await ready;
+
+    // Bind should have succeeded despite the stale file.
+    const postBindDeadline = Date.now() + 2000;
+    let socketReady = false;
+    while (Date.now() < postBindDeadline) {
+      try {
+        const c = await connectControlSocket(expectedPath, { timeoutMs: 200 });
+        c.close();
+        socketReady = true;
+        break;
+      } catch {
+        await new Promise((r) => setTimeout(r, 50));
+      }
+    }
+    expect(socketReady).toBe(true);
+
+    if (shutdownHook) await (shutdownHook as () => Promise<void>)();
+  });
+});

--- a/packages/core/src/daemon/control-socket.test.ts
+++ b/packages/core/src/daemon/control-socket.test.ts
@@ -1,0 +1,414 @@
+import { Database } from 'bun:sqlite';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createEventBus } from '../events/bus.js';
+import { createEventStore } from '../events/store.js';
+import type { AgentEvent, EventSourceInstance } from '../events/types.js';
+import {
+  type ControlSocketContext,
+  connectControlSocket,
+  controlSocketPath,
+  encodeControlSocketMessage,
+  handleControlSocketRequest,
+  isControlSocketRequest,
+  startControlSocket,
+} from './control-socket.js';
+
+function mockSource(id: string, type: string): EventSourceInstance {
+  return {
+    id,
+    type,
+    async start() {
+      /* noop */
+    },
+    async stop() {
+      /* noop */
+    },
+    async pause() {
+      /* noop */
+    },
+    async resume() {
+      /* noop */
+    },
+    async health() {
+      return { status: 'healthy' as const };
+    },
+    metrics() {
+      return {
+        eventsPublished: 0,
+        lastEventAt: null,
+      };
+    },
+  };
+}
+
+describe('isControlSocketRequest', () => {
+  test('accepts the five known ops', () => {
+    expect(isControlSocketRequest({ id: 'a', op: 'ping' })).toBe(true);
+    expect(isControlSocketRequest({ id: 'b', op: 'status' })).toBe(true);
+    expect(isControlSocketRequest({ id: 'c', op: 'reload' })).toBe(true);
+    expect(isControlSocketRequest({ id: 'd', op: 'shutdown' })).toBe(true);
+    expect(
+      isControlSocketRequest({ id: 'e', op: 'dlq.requeue', params: { eventId: 'evt-1' } }),
+    ).toBe(true);
+  });
+
+  test('rejects dlq.requeue without params.eventId', () => {
+    expect(isControlSocketRequest({ id: 'x', op: 'dlq.requeue' })).toBe(false);
+    expect(isControlSocketRequest({ id: 'x', op: 'dlq.requeue', params: {} })).toBe(false);
+    expect(isControlSocketRequest({ id: 'x', op: 'dlq.requeue', params: { eventId: '' } })).toBe(
+      false,
+    );
+  });
+
+  test('rejects unknown ops and malformed objects', () => {
+    expect(isControlSocketRequest(null)).toBe(false);
+    expect(isControlSocketRequest({})).toBe(false);
+    expect(isControlSocketRequest({ id: 1, op: 'ping' })).toBe(false);
+    expect(isControlSocketRequest({ id: 'a', op: 'evil' })).toBe(false);
+  });
+});
+
+describe('encodeControlSocketMessage', () => {
+  test('emits one JSON object per line with a trailing newline', () => {
+    const line = encodeControlSocketMessage({ id: 'q1', op: 'ping' });
+    expect(line.endsWith('\n')).toBe(true);
+    const parsed = JSON.parse(line.trim()) as { id: string; op: string };
+    expect(parsed.id).toBe('q1');
+    expect(parsed.op).toBe('ping');
+  });
+});
+
+describe('controlSocketPath', () => {
+  test('places unix sockets under ~/.declaragent/<agentId>/', () => {
+    // Skipped on Windows where the pipe-path shape is different; the
+    // test harness runs on macOS/Linux in CI.
+    const p = controlSocketPath('billing-agent', '/home/u');
+    expect(p === '/home/u/.declaragent/billing-agent/control.sock' || p.startsWith('\\\\.\\')).toBe(
+      true,
+    );
+  });
+
+  test('sanitizes the agent id for the filesystem', () => {
+    const p = controlSocketPath('bad/../id', '/home/u');
+    expect(p.includes('/..')).toBe(false);
+  });
+});
+
+describe('handleControlSocketRequest — op dispatch table', () => {
+  function fixtureContext(overrides: Partial<ControlSocketContext> = {}): ControlSocketContext {
+    return {
+      agentId: 'billing-agent',
+      pid: 4242,
+      startedAt: Date.now() - 1000,
+      sources: () => [mockSource('src-1', 'webhook'), mockSource('src-2', 'cron')],
+      lastEventAt: () => 1700000000000,
+      ...overrides,
+    };
+  }
+
+  test('ping returns pong', async () => {
+    const resp = await handleControlSocketRequest({ id: 'q1', op: 'ping' }, fixtureContext());
+    expect(resp.op).toBe('ping');
+    if (resp.op === 'ping' && 'result' in resp) {
+      expect(resp.result.pong).toBe(true);
+    }
+  });
+
+  test('status returns pid, sources, uptime, lastEventAt', async () => {
+    const ctx = fixtureContext();
+    const resp = await handleControlSocketRequest({ id: 'q2', op: 'status' }, ctx);
+    expect(resp.op).toBe('status');
+    if (resp.op === 'status' && 'result' in resp) {
+      expect(resp.result.pid).toBe(4242);
+      expect(resp.result.agentId).toBe('billing-agent');
+      expect(resp.result.uptimeMs).toBeGreaterThanOrEqual(500);
+      expect(resp.result.sources).toEqual([
+        { id: 'src-1', type: 'webhook' },
+        { id: 'src-2', type: 'cron' },
+      ]);
+      expect(resp.result.lastEventAt).toBe(1700000000000);
+    }
+  });
+
+  test('status omits lastEventAt when there are no events', async () => {
+    const ctx = fixtureContext({ lastEventAt: () => undefined });
+    const resp = await handleControlSocketRequest({ id: 'q2', op: 'status' }, ctx);
+    if (resp.op === 'status' && 'result' in resp) {
+      expect('lastEventAt' in resp.result).toBe(false);
+    }
+  });
+
+  test('dlq.requeue routes through the requeue helper and returns ok on success', async () => {
+    const db = new Database(':memory:', { create: true });
+    const store = createEventStore({ db });
+    const bus = createEventBus();
+    const event: AgentEvent = {
+      id: 'evt-socket-1',
+      kind: 'trigger.fire',
+      source: { type: 'self', reason: 'retry' },
+      target: { type: 'skill', name: 'do', inputs: {} },
+      timestamp: Date.now(),
+      payload: {},
+      auth: { kind: 'internal' },
+    };
+    await store.record(event);
+    await store.upsertRejection('evt-socket-1', 'circuit-open', undefined);
+
+    const ctx = fixtureContext({ bus, store });
+    const resp = await handleControlSocketRequest(
+      { id: 'q3', op: 'dlq.requeue', params: { eventId: 'evt-socket-1' } },
+      ctx,
+    );
+    expect(resp.op).toBe('dlq.requeue');
+    if (resp.op === 'dlq.requeue' && 'result' in resp) {
+      expect(resp.result.ok).toBe(true);
+    }
+    db.close();
+  });
+
+  test('dlq.requeue returns ENOBUS when the daemon has no bus wired', async () => {
+    const ctx = fixtureContext();
+    const resp = await handleControlSocketRequest(
+      { id: 'q4', op: 'dlq.requeue', params: { eventId: 'any' } },
+      ctx,
+    );
+    expect(resp.op).toBe('dlq.requeue');
+    if (resp.op === 'dlq.requeue' && 'error' in resp) {
+      expect(resp.error.code).toBe('ENOBUS');
+    }
+  });
+
+  test('dlq.requeue result flags dlq-miss on the second call (idempotent)', async () => {
+    const db = new Database(':memory:', { create: true });
+    const store = createEventStore({ db });
+    const bus = createEventBus();
+    const event: AgentEvent = {
+      id: 'evt-dup',
+      kind: 'trigger.fire',
+      source: { type: 'self', reason: 'retry' },
+      target: { type: 'skill', name: 'x', inputs: {} },
+      timestamp: Date.now(),
+      payload: {},
+      auth: { kind: 'internal' },
+    };
+    await store.record(event);
+    await store.upsertRejection('evt-dup', 'no-handler', undefined);
+
+    const ctx = fixtureContext({ bus, store });
+    const first = await handleControlSocketRequest(
+      { id: 'q5', op: 'dlq.requeue', params: { eventId: 'evt-dup' } },
+      ctx,
+    );
+    const second = await handleControlSocketRequest(
+      { id: 'q6', op: 'dlq.requeue', params: { eventId: 'evt-dup' } },
+      ctx,
+    );
+    if (first.op === 'dlq.requeue' && 'result' in first) expect(first.result.ok).toBe(true);
+    if (second.op === 'dlq.requeue' && 'result' in second) {
+      expect(second.result.ok).toBe(false);
+      if (!second.result.ok) expect(second.result.reason).toBe('dlq-miss');
+    }
+    db.close();
+  });
+
+  test('reload returns unsupported when no reload handler is wired', async () => {
+    const resp = await handleControlSocketRequest({ id: 'q7', op: 'reload' }, fixtureContext());
+    expect(resp.op).toBe('reload');
+    if (resp.op === 'reload' && 'result' in resp) {
+      expect(resp.result.reloaded).toBe(false);
+      expect(resp.result.reason).toBe('unsupported');
+    }
+  });
+
+  test('reload delegates to the provided handler', async () => {
+    const ctx = fixtureContext({
+      reload: async () => ({
+        reloaded: false,
+        reason: 'skills-changed',
+        message: 'skill set drifted; restart up to apply',
+      }),
+    });
+    const resp = await handleControlSocketRequest({ id: 'q8', op: 'reload' }, ctx);
+    if (resp.op === 'reload' && 'result' in resp) {
+      expect(resp.result.reloaded).toBe(false);
+      expect(resp.result.reason).toBe('skills-changed');
+    }
+  });
+
+  test('shutdown acks synchronously and fires the shutdown hook in the background', async () => {
+    let fired = false;
+    const ctx = fixtureContext({
+      shutdown: () => {
+        fired = true;
+      },
+    });
+    const resp = await handleControlSocketRequest({ id: 'q9', op: 'shutdown' }, ctx);
+    expect(resp.op).toBe('shutdown');
+    if (resp.op === 'shutdown' && 'result' in resp) {
+      expect(resp.result.ok).toBe(true);
+    }
+    // Allow the microtask/macrotask to settle.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(fired).toBe(true);
+  });
+
+  test('handler exceptions are caught and returned as EHANDLER errors', async () => {
+    const ctx = fixtureContext({
+      reload: () => {
+        throw new Error('boom');
+      },
+    });
+    const resp = await handleControlSocketRequest({ id: 'q10', op: 'reload' }, ctx);
+    if (resp.op === 'reload' && 'error' in resp) {
+      expect(resp.error.code).toBe('EHANDLER');
+      expect(resp.error.message).toContain('boom');
+    }
+  });
+});
+
+describe('control socket server — end-to-end', () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'declaragent-control-sock-'));
+  });
+  afterEach(() => {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  function ctxFor(agentId: string, opts: Partial<ControlSocketContext> = {}): ControlSocketContext {
+    return {
+      agentId,
+      pid: process.pid,
+      startedAt: Date.now(),
+      sources: () => [],
+      lastEventAt: () => undefined,
+      ...opts,
+    };
+  }
+
+  test('stale socket on startup is unlinked and rebound', async () => {
+    const socketPath = join(tmpDir, 'control.sock');
+    // Simulate a stale socket from a prior crash.
+    const first = await startControlSocket({
+      context: ctxFor('a1'),
+      socketPath,
+    });
+    await first.close();
+    // Leave a stale file behind deliberately — this is what we're
+    // testing so if close() already unlinks, rebinding still succeeds
+    // anyway (primary invariant: next bind never wedges).
+    const second = await startControlSocket({
+      context: ctxFor('a1'),
+      socketPath,
+    });
+    // Second bind succeeded — that's the assertion.
+    const client = await connectControlSocket(socketPath);
+    const resp = await client.call({ id: 'ping-1', op: 'ping' });
+    if (resp.op === 'ping' && 'result' in resp) {
+      expect(resp.result.pong).toBe(true);
+    }
+    client.close();
+    await second.close();
+  });
+
+  test('all five ops are reachable over the real socket transport', async () => {
+    const socketPath = join(tmpDir, 'control.sock');
+    let shutdownFired = false;
+    const server = await startControlSocket({
+      context: ctxFor('billing', {
+        sources: () => [mockSource('webhook-1', 'webhook')],
+        lastEventAt: () => 1700000000000,
+        reload: () => ({ reloaded: true }),
+        shutdown: () => {
+          shutdownFired = true;
+        },
+      }),
+      socketPath,
+    });
+
+    const client = await connectControlSocket(socketPath);
+    try {
+      const ping = await client.call({ id: '1', op: 'ping' });
+      expect(ping.op === 'ping' && 'result' in ping && ping.result.pong).toBe(true);
+
+      const status = await client.call({ id: '2', op: 'status' });
+      expect(status.op === 'status' && 'result' in status && status.result.pid).toBe(process.pid);
+      if (status.op === 'status' && 'result' in status) {
+        expect(status.result.sources).toEqual([{ id: 'webhook-1', type: 'webhook' }]);
+        expect(status.result.lastEventAt).toBe(1700000000000);
+      }
+
+      const requeueResp = await client.call({
+        id: '3',
+        op: 'dlq.requeue',
+        params: { eventId: 'nonexistent' },
+      });
+      // No bus wired → ENOBUS.
+      expect(requeueResp.op === 'dlq.requeue' && 'error' in requeueResp).toBe(true);
+
+      const reload = await client.call({ id: '4', op: 'reload' });
+      if (reload.op === 'reload' && 'result' in reload) {
+        expect(reload.result.reloaded).toBe(true);
+      }
+
+      const shutdown = await client.call({ id: '5', op: 'shutdown' });
+      expect(shutdown.op === 'shutdown' && 'result' in shutdown && shutdown.result.ok).toBe(true);
+      await new Promise((r) => setTimeout(r, 20));
+      expect(shutdownFired).toBe(true);
+    } finally {
+      client.close();
+      await server.close();
+    }
+  });
+
+  test('concurrent calls on one connection correlate by id', async () => {
+    const socketPath = join(tmpDir, 'control.sock');
+    const server = await startControlSocket({ context: ctxFor('a2'), socketPath });
+    const client = await connectControlSocket(socketPath);
+    try {
+      const [a, b, c] = await Promise.all([
+        client.call({ id: 'A', op: 'ping' }),
+        client.call({ id: 'B', op: 'status' }),
+        client.call({ id: 'C', op: 'ping' }),
+      ]);
+      expect(a.id).toBe('A');
+      expect(b.id).toBe('B');
+      expect(c.id).toBe('C');
+    } finally {
+      client.close();
+      await server.close();
+    }
+  });
+
+  test('malformed request gets a typed EBADREQ error rather than a reset', async () => {
+    const socketPath = join(tmpDir, 'control.sock');
+    const server = await startControlSocket({ context: ctxFor('a3'), socketPath });
+    try {
+      // Speak directly over the socket to send a garbage line.
+      const { connect } = await import('node:net');
+      const socket = connect(socketPath);
+      socket.setEncoding('utf8');
+      await new Promise<void>((resolve, reject) => {
+        socket.once('connect', () => resolve());
+        socket.once('error', reject);
+      });
+      const got = new Promise<string>((resolve) => {
+        socket.on('data', (buf) => resolve(typeof buf === 'string' ? buf : buf.toString('utf8')));
+      });
+      socket.write('{"id":"x","op":"not-a-real-op"}\n');
+      const line = await got;
+      const parsed = JSON.parse(line.trim()) as { error?: { code: string } };
+      expect(parsed.error?.code).toBe('EBADREQ');
+      socket.end();
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/packages/core/src/daemon/control-socket.ts
+++ b/packages/core/src/daemon/control-socket.ts
@@ -1,0 +1,568 @@
+/**
+ * Control socket for the `declaragent up` daemon.
+ *
+ * A Unix domain socket (Windows: named pipe) bound at
+ * `~/.declaragent/<agent-id>/control.sock` that speaks a minimal
+ * NDJSON-over-stream JSON-RPC dialect. Unlike the richer
+ * `packages/core/src/events/daemon.ts` control plane — which is scoped to
+ * a standalone `startDaemon` process — this socket is specifically for
+ * the multi-agent `up` loop and ships five fixed ops:
+ *
+ *   - `ping`         → `{ pong: true }`. Cheap health check.
+ *   - `status`       → `{ pid, uptimeMs, sources, lastEventAt }`.
+ *                       Replaces the `up-state.json` read in `ps`.
+ *   - `dlq.requeue`  → re-injects a rejected event onto the bus via
+ *                       `requeue()` in {@link ../events/dlq.ts}.
+ *   - `reload`       → best-effort hot-reload of sources. Returns
+ *                       `{ reloaded: false, reason: 'skills-changed' }`
+ *                       when the declarative skill set has drifted
+ *                       (we refuse rather than half-apply).
+ *   - `shutdown`     → acks then triggers the daemon's shutdown hook.
+ *
+ * The op set is intentionally fixed; this is not a pluggable registry.
+ * Broader extensibility lives in the Phase-3 `startDaemon` path already.
+ *
+ * Protocol: one JSON object per line. Each request carries a client-side
+ * `id` (string) so multiple concurrent calls can be correlated.
+ * Responses echo that id. Errors use a `{ error: { code, message } }`
+ * shape.
+ *
+ * Hardening notes:
+ *   - Socket file is chmod'd to 0600 so other local users can't speak
+ *     to the daemon.
+ *   - A stale socket from a previous crash is unlinked on startup —
+ *     never wedges `up`. (Windows named-pipe path is unique-per-process
+ *     so stale-pipe handling is a no-op.)
+ *   - Auto-clean on process exit via the returned handle's `close()`.
+ *   - Malformed / unknown-op requests get a typed error reply rather
+ *     than a TCP-reset so operators can see what went wrong.
+ *
+ * @since 0.6.x
+ */
+
+import { chmodSync, existsSync, mkdirSync, unlinkSync } from 'node:fs';
+import { type Server, type Socket, createServer } from 'node:net';
+import { homedir, platform } from 'node:os';
+import { dirname, join } from 'node:path';
+import { NDJSONDecoder } from '../events/control-protocol.js';
+import { type RequeueResult, requeue } from '../events/dlq.js';
+import type { EventStore } from '../events/store.js';
+import type { EventBus, EventSourceInstance } from '../events/types.js';
+import type { Logger } from '../types/logger.js';
+
+// ── Op protocol ─────────────────────────────────────────────────────────
+
+/** Every request carries a caller-supplied correlation id. */
+export interface ControlSocketRequestBase {
+  readonly id: string;
+}
+
+export type ControlSocketRequest =
+  | (ControlSocketRequestBase & { readonly op: 'ping' })
+  | (ControlSocketRequestBase & { readonly op: 'status' })
+  | (ControlSocketRequestBase & {
+      readonly op: 'dlq.requeue';
+      readonly params: { readonly eventId: string };
+    })
+  | (ControlSocketRequestBase & { readonly op: 'reload' })
+  | (ControlSocketRequestBase & { readonly op: 'shutdown' });
+
+export type ControlSocketOp = ControlSocketRequest['op'];
+
+export interface ControlSocketStatus {
+  readonly pid: number;
+  readonly agentId: string;
+  readonly startedAt: number;
+  readonly uptimeMs: number;
+  readonly sources: readonly { readonly id: string; readonly type: string }[];
+  /** ms epoch of the last event the daemon observed; undefined if none. */
+  readonly lastEventAt?: number;
+}
+
+export interface ControlSocketReloadResult {
+  readonly reloaded: boolean;
+  /** Populated when `reloaded === false` so callers can message the user. */
+  readonly reason?: 'skills-changed' | 'unsupported' | 'no-handler';
+  readonly message?: string;
+}
+
+export interface ControlSocketResultByOp {
+  readonly ping: { readonly pong: true };
+  readonly status: ControlSocketStatus;
+  readonly 'dlq.requeue': RequeueResult;
+  readonly reload: ControlSocketReloadResult;
+  readonly shutdown: { readonly ok: true };
+}
+
+export interface ControlSocketErrorBody {
+  readonly code: string;
+  readonly message: string;
+}
+
+/** Distribute over op so narrowing on `resp.op` narrows `resp.result`. */
+export type ControlSocketResponse = {
+  [Op in ControlSocketOp]:
+    | { readonly id: string; readonly op: Op; readonly result: ControlSocketResultByOp[Op] }
+    | { readonly id: string; readonly op: Op; readonly error: ControlSocketErrorBody };
+}[ControlSocketOp];
+
+/** Narrow guard. Rejects anything that doesn't fit the request shape. */
+export function isControlSocketRequest(value: unknown): value is ControlSocketRequest {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v.id !== 'string' || typeof v.op !== 'string') return false;
+  switch (v.op) {
+    case 'ping':
+    case 'status':
+    case 'reload':
+    case 'shutdown':
+      return true;
+    case 'dlq.requeue': {
+      const p = v.params as { eventId?: unknown } | undefined;
+      return typeof p?.eventId === 'string' && p.eventId.length > 0;
+    }
+    default:
+      return false;
+  }
+}
+
+/** Encode a request or response as a single NDJSON line (trailing `\n`). */
+export function encodeControlSocketMessage(
+  value: ControlSocketRequest | ControlSocketResponse,
+): string {
+  return `${JSON.stringify(value)}\n`;
+}
+
+// ── Handlers ────────────────────────────────────────────────────────────
+
+/**
+ * Context exposed to each op. The caller assembles this once at bind
+ * time and passes it to the server; handlers can read-through it on every
+ * request.
+ */
+export interface ControlSocketContext {
+  readonly agentId: string;
+  /** Pid to report in `status`. Defaults to `process.pid` when omitted. */
+  readonly pid: number;
+  /** ms epoch when the daemon started. */
+  readonly startedAt: number;
+  /** Snapshot of bound sources — returned verbatim in `status.sources`. */
+  readonly sources: () => readonly EventSourceInstance[];
+  /** Last event timestamp; the daemon updates this from its bus subscriber. */
+  readonly lastEventAt: () => number | undefined;
+  /**
+   * Called when `dlq.requeue` is invoked. Callers wire this to
+   * {@link requeue} with their bus + store. Returning undefined means
+   * the daemon has no bus wired yet → the op returns `{ code: 'ENOBUS' }`.
+   */
+  readonly bus?: EventBus;
+  readonly store?: EventStore;
+  /**
+   * Called when `reload` is invoked. Should return a result describing
+   * what happened. If omitted, `reload` responds with `unsupported`.
+   */
+  readonly reload?: () => Promise<ControlSocketReloadResult> | ControlSocketReloadResult;
+  /**
+   * Called when `shutdown` is invoked. Should initiate graceful stop;
+   * the socket acks immediately and does not await this. If omitted,
+   * the op still acks but no shutdown is triggered (test harness use).
+   */
+  readonly shutdown?: () => Promise<void> | void;
+  readonly logger?: Logger;
+}
+
+/**
+ * Pure op dispatch. No I/O — both the socket server and tests call this
+ * directly. Returns a response the caller serialises back to the client.
+ */
+export async function handleControlSocketRequest(
+  request: ControlSocketRequest,
+  ctx: ControlSocketContext,
+): Promise<ControlSocketResponse> {
+  try {
+    switch (request.op) {
+      case 'ping':
+        return { id: request.id, op: 'ping', result: { pong: true } };
+
+      case 'status': {
+        const sources = ctx.sources().map((s) => ({ id: s.id, type: s.type }));
+        const status: ControlSocketStatus = {
+          pid: ctx.pid,
+          agentId: ctx.agentId,
+          startedAt: ctx.startedAt,
+          uptimeMs: Date.now() - ctx.startedAt,
+          sources,
+          ...(ctx.lastEventAt() !== undefined && { lastEventAt: ctx.lastEventAt() as number }),
+        };
+        return { id: request.id, op: 'status', result: status };
+      }
+
+      case 'dlq.requeue': {
+        if (!ctx.bus || !ctx.store) {
+          return {
+            id: request.id,
+            op: 'dlq.requeue',
+            error: {
+              code: 'ENOBUS',
+              message: 'daemon has no bus/store wired — cannot requeue',
+            },
+          };
+        }
+        const result = await requeue({
+          bus: ctx.bus,
+          store: ctx.store,
+          eventId: request.params.eventId,
+        });
+        return { id: request.id, op: 'dlq.requeue', result };
+      }
+
+      case 'reload': {
+        if (!ctx.reload) {
+          return {
+            id: request.id,
+            op: 'reload',
+            result: {
+              reloaded: false,
+              reason: 'unsupported',
+              message: 'reload is not supported by this daemon',
+            },
+          };
+        }
+        const result = await ctx.reload();
+        return { id: request.id, op: 'reload', result };
+      }
+
+      case 'shutdown': {
+        // Kick off shutdown without awaiting — operators expect the ack
+        // before the daemon actually tears down.
+        if (ctx.shutdown) {
+          void Promise.resolve()
+            .then(() => ctx.shutdown?.())
+            .catch((err) => {
+              ctx.logger?.warn('control-socket.shutdown-failed', {
+                err: err instanceof Error ? err.message : String(err),
+              });
+            });
+        }
+        return { id: request.id, op: 'shutdown', result: { ok: true } };
+      }
+    }
+  } catch (err) {
+    const body: ControlSocketErrorBody = {
+      code: 'EHANDLER',
+      message: err instanceof Error ? err.message : String(err),
+    };
+    // Type-narrow the op literal into each arm so the response stays
+    // discriminated.
+    switch (request.op) {
+      case 'ping':
+        return { id: request.id, op: 'ping', error: body };
+      case 'status':
+        return { id: request.id, op: 'status', error: body };
+      case 'dlq.requeue':
+        return { id: request.id, op: 'dlq.requeue', error: body };
+      case 'reload':
+        return { id: request.id, op: 'reload', error: body };
+      case 'shutdown':
+        return { id: request.id, op: 'shutdown', error: body };
+    }
+  }
+}
+
+// ── Path helpers ────────────────────────────────────────────────────────
+
+/**
+ * Returns `true` on Windows, where Unix domain sockets at filesystem paths
+ * aren't reachable via the same primitives. Node's `net.createServer`
+ * does accept a `\\.\pipe\...` path to create a Windows named pipe, which
+ * we use as the fallback transport. Callers don't need to branch.
+ */
+export function isWindows(): boolean {
+  return platform() === 'win32';
+}
+
+/**
+ * Canonical control socket path for an agent. Must match the client-side
+ * resolver in the CLI (`ps`, future `declaragent control *` verbs).
+ *
+ * Honors `$HOME` when the env var is set — matching the same behavior
+ * `packages/cli/src/paths.ts#configDir` uses — so a test that redirects
+ * HOME to a tmp dir gets a tmp-scoped socket rather than writing into
+ * the user's real `~/.declaragent`.
+ *
+ * @param agentId  The agent identifier from `agent.yaml#name`.
+ * @param root     Optional override. Defaults to `$HOME` then `os.homedir()`.
+ */
+export function controlSocketPath(agentId: string, root?: string): string {
+  const sanitized = sanitizeAgentId(agentId);
+  if (isWindows()) {
+    // Named pipes live in the special NT namespace — no filesystem path.
+    // We still return a stable identifier so both sides agree.
+    return `\\\\.\\pipe\\declaragent-${sanitized}`;
+  }
+  const home = root ?? process.env.HOME ?? homedir();
+  return join(home, '.declaragent', sanitized, 'control.sock');
+}
+
+function sanitizeAgentId(id: string): string {
+  // Matches the sanitizer in up-lifecycle.ts; defensive for any id the
+  // user renames on disk that still slipped past yaml validation.
+  return id.replace(/[^A-Za-z0-9._-]/g, '_');
+}
+
+// ── Server ──────────────────────────────────────────────────────────────
+
+export interface ControlSocketServer {
+  readonly socketPath: string;
+  /** Close the listener + unlink the socket file. Idempotent. */
+  close(): Promise<void>;
+}
+
+export interface StartControlSocketOptions {
+  readonly context: ControlSocketContext;
+  /**
+   * Override for the socket path. Defaults to
+   * {@link controlSocketPath}(context.agentId).
+   */
+  readonly socketPath?: string;
+  /**
+   * When `true` (default) and a socket file already exists at the target
+   * path, it's unlinked before bind. Prevents a stale socket from a
+   * crashed `up` wedging the next startup.
+   */
+  readonly force?: boolean;
+}
+
+/**
+ * Bind a control socket server. On Unix this creates a Unix domain
+ * socket chmod'd to 0600; on Windows this creates a named pipe with the
+ * same NDJSON protocol.
+ *
+ * The returned handle has `close()` which gracefully stops the listener
+ * + unlinks the socket file.
+ */
+export async function startControlSocket(
+  options: StartControlSocketOptions,
+): Promise<ControlSocketServer> {
+  const { context } = options;
+  const socketPath = options.socketPath ?? controlSocketPath(context.agentId);
+  const force = options.force ?? true;
+
+  if (!isWindows()) {
+    // Parent dir must exist for bind to succeed.
+    try {
+      mkdirSync(dirname(socketPath), { recursive: true });
+    } catch {
+      // ignore — bind will surface the error if mkdir genuinely failed.
+    }
+    if (force && existsSync(socketPath)) {
+      try {
+        unlinkSync(socketPath);
+      } catch {
+        // Not fatal — maybe it wasn't a socket; listen() will throw if
+        // the path is unusable.
+      }
+    }
+  }
+
+  const server: Server = createServer((socket) => handleConnection(socket, context));
+  // Reject new connections if the server is shutting down rather than
+  // hang the socket.
+  server.on('error', (err) => {
+    context.logger?.warn('control-socket.server-error', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const onError = (err: Error): void => {
+      server.removeListener('listening', onListening);
+      reject(err);
+    };
+    const onListening = (): void => {
+      server.removeListener('error', onError);
+      resolve();
+    };
+    server.once('error', onError);
+    server.once('listening', onListening);
+    server.listen(socketPath);
+  });
+
+  if (!isWindows()) {
+    try {
+      chmodSync(socketPath, 0o600);
+    } catch {
+      // Non-fatal on filesystems where chmod is a no-op; the file is
+      // still in a user-owned dir.
+    }
+  }
+
+  let closed = false;
+  const close = async (): Promise<void> => {
+    if (closed) return;
+    closed = true;
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+    if (!isWindows() && existsSync(socketPath)) {
+      try {
+        unlinkSync(socketPath);
+      } catch {
+        // ignore
+      }
+    }
+  };
+
+  return { socketPath, close };
+}
+
+function handleConnection(socket: Socket, ctx: ControlSocketContext): void {
+  const decoder = new NDJSONDecoder();
+  socket.setEncoding('utf8');
+
+  socket.on('data', async (chunk: string | Buffer) => {
+    const text = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+    const parsed = decoder.push(text);
+    for (const entry of parsed) {
+      if (!isControlSocketRequest(entry)) {
+        // Malformed or unknown op — respond with a typed error so the
+        // operator can see what went wrong. Use a fabricated id + op
+        // when we can pull them out of the input.
+        const maybe = (entry ?? {}) as { id?: unknown; op?: unknown };
+        const id = typeof maybe.id === 'string' ? maybe.id : 'invalid';
+        writeResponse(socket, {
+          id,
+          op: 'ping', // placeholder; the client should key off `error`
+          error: {
+            code: 'EBADREQ',
+            message: `malformed or unknown control-socket request: ${JSON.stringify(maybe)}`,
+          },
+        } as ControlSocketResponse);
+        continue;
+      }
+      try {
+        const response = await handleControlSocketRequest(entry, ctx);
+        writeResponse(socket, response);
+      } catch (err) {
+        writeResponse(socket, {
+          id: entry.id,
+          op: entry.op,
+          error: {
+            code: 'EUNHANDLED',
+            message: err instanceof Error ? err.message : String(err),
+          },
+        } as ControlSocketResponse);
+      }
+    }
+  });
+
+  socket.on('error', () => {
+    // Client disconnected or write failed — nothing to do.
+  });
+}
+
+function writeResponse(socket: Socket, response: ControlSocketResponse): void {
+  try {
+    socket.write(encodeControlSocketMessage(response));
+  } catch {
+    // Best-effort; socket may already be closed.
+  }
+}
+
+// ── Client ──────────────────────────────────────────────────────────────
+
+import { connect } from 'node:net';
+
+export interface ControlSocketClient {
+  /**
+   * Send one request; resolves with the matching response. The generic
+   * `Op` is inferred from the request so callers can narrow the result
+   * without a cast (`(resp: { op: 'ping'; result: { pong: true } })`).
+   */
+  call(request: ControlSocketRequest): Promise<ControlSocketResponse>;
+  close(): void;
+}
+
+/**
+ * Open a client to a control socket. Multiple `call()` invocations share
+ * the same connection; responses are correlated by the request `id`.
+ */
+export async function connectControlSocket(
+  socketPath: string,
+  options: { readonly timeoutMs?: number } = {},
+): Promise<ControlSocketClient> {
+  const timeoutMs = options.timeoutMs ?? 2000;
+
+  const socket: Socket = await new Promise<Socket>((resolve, reject) => {
+    const s = connect(socketPath);
+    s.setEncoding('utf8');
+    const timer = setTimeout(() => {
+      s.destroy();
+      reject(new Error(`control-socket connect timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    const onErr = (err: Error): void => {
+      clearTimeout(timer);
+      s.removeListener('connect', onConn);
+      reject(err);
+    };
+    const onConn = (): void => {
+      clearTimeout(timer);
+      s.removeListener('error', onErr);
+      resolve(s);
+    };
+    s.once('error', onErr);
+    s.once('connect', onConn);
+  });
+
+  const decoder = new NDJSONDecoder();
+  const pending = new Map<string, (resp: ControlSocketResponse) => void>();
+  let closed = false;
+
+  socket.on('data', (chunk: string | Buffer) => {
+    const text = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+    const parsed = decoder.push(text);
+    for (const entry of parsed) {
+      if (!entry || typeof entry !== 'object' || !('id' in entry)) continue;
+      const id = (entry as { id: string }).id;
+      const resolver = pending.get(id);
+      if (resolver) {
+        pending.delete(id);
+        resolver(entry as ControlSocketResponse);
+      }
+    }
+  });
+
+  socket.on('close', () => {
+    closed = true;
+    for (const [id, resolver] of pending) {
+      resolver({
+        id,
+        op: 'ping',
+        error: { code: 'ESOCKETCLOSED', message: 'control socket closed before response' },
+      } as ControlSocketResponse);
+    }
+    pending.clear();
+  });
+
+  return {
+    async call(request: ControlSocketRequest): Promise<ControlSocketResponse> {
+      if (closed) {
+        return {
+          id: request.id,
+          op: request.op,
+          error: { code: 'ESOCKETCLOSED', message: 'control socket is closed' },
+        } as ControlSocketResponse;
+      }
+      return new Promise<ControlSocketResponse>((resolve) => {
+        pending.set(request.id, (resp) => resolve(resp));
+        socket.write(encodeControlSocketMessage(request));
+      });
+    },
+    close(): void {
+      if (!closed) {
+        closed = true;
+        socket.end();
+      }
+    },
+  };
+}

--- a/packages/core/src/daemon/index.ts
+++ b/packages/core/src/daemon/index.ts
@@ -1,0 +1,23 @@
+export {
+  connectControlSocket,
+  controlSocketPath,
+  encodeControlSocketMessage,
+  handleControlSocketRequest,
+  isControlSocketRequest,
+  isWindows,
+  startControlSocket,
+} from './control-socket.js';
+export type {
+  ControlSocketClient,
+  ControlSocketContext,
+  ControlSocketErrorBody,
+  ControlSocketOp,
+  ControlSocketReloadResult,
+  ControlSocketRequest,
+  ControlSocketRequestBase,
+  ControlSocketResponse,
+  ControlSocketResultByOp,
+  ControlSocketServer,
+  ControlSocketStatus,
+  StartControlSocketOptions,
+} from './control-socket.js';

--- a/packages/core/src/events/dlq.test.ts
+++ b/packages/core/src/events/dlq.test.ts
@@ -1,0 +1,131 @@
+import { Database } from 'bun:sqlite';
+import { describe, expect, test } from 'bun:test';
+import { createEventBus } from './bus.js';
+import { requeue } from './dlq.js';
+import { createEventStore } from './store.js';
+import type { AgentEvent } from './types.js';
+
+function makeEvent(id: string): AgentEvent {
+  return {
+    id,
+    kind: 'trigger.fire',
+    source: { type: 'self', reason: 'retry' },
+    target: { type: 'skill', name: 'do-thing', inputs: {} },
+    timestamp: Date.now(),
+    payload: { hello: 'world' },
+    auth: { kind: 'internal' },
+  };
+}
+
+function memDb(): Database {
+  return new Database(':memory:', { create: true });
+}
+
+describe('requeue', () => {
+  test('publishes the event and deletes the DLQ row on success', async () => {
+    const db = memDb();
+    const store = createEventStore({ db });
+    const bus = createEventBus();
+
+    const event = makeEvent('evt-1');
+    await store.record(event);
+    await store.upsertRejection('evt-1', 'circuit-open', 'breaker tripped');
+
+    const seen: AgentEvent[] = [];
+    bus.subscribe('*', async (e) => {
+      seen.push(e);
+    });
+
+    const result = await requeue({ store, bus, eventId: 'evt-1' });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.eventId).toBe('evt-1');
+      expect(result.attemptsBeforeRequeue).toBe(1);
+    }
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.id).toBe('evt-1');
+    expect(await store.getRejection('evt-1')).toBeUndefined();
+
+    db.close();
+  });
+
+  test('returns dlq-miss when the event is not in the rejections table', async () => {
+    const db = memDb();
+    const store = createEventStore({ db });
+    const bus = createEventBus();
+
+    const result = await requeue({ store, bus, eventId: 'never-rejected' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('dlq-miss');
+    }
+
+    db.close();
+  });
+
+  test('returns event-miss when rejection exists but the event body is vacuumed', async () => {
+    const db = memDb();
+    const store = createEventStore({ db });
+    const bus = createEventBus();
+
+    await store.upsertRejection('ghost-event', 'rate-limit', undefined);
+
+    const result = await requeue({ store, bus, eventId: 'ghost-event' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('event-miss');
+    }
+
+    db.close();
+  });
+
+  test('second call for the same id returns dlq-miss (idempotent, no duplicate publish)', async () => {
+    const db = memDb();
+    const store = createEventStore({ db });
+    const bus = createEventBus();
+
+    const event = makeEvent('evt-2');
+    await store.record(event);
+    await store.upsertRejection('evt-2', 'no-handler', undefined);
+
+    const seen: AgentEvent[] = [];
+    bus.subscribe('*', async (e) => {
+      seen.push(e);
+    });
+
+    const first = await requeue({ store, bus, eventId: 'evt-2' });
+    const second = await requeue({ store, bus, eventId: 'evt-2' });
+
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(false);
+    if (!second.ok) {
+      expect(second.reason).toBe('dlq-miss');
+    }
+    // Critical: the second call MUST NOT have republished.
+    expect(seen).toHaveLength(1);
+
+    db.close();
+  });
+
+  test('carries the attempt count from the rejection row', async () => {
+    const db = memDb();
+    const store = createEventStore({ db });
+    const bus = createEventBus();
+
+    const event = makeEvent('evt-3');
+    await store.record(event);
+    // Three rejections before requeue.
+    await store.upsertRejection('evt-3', 'circuit-open', undefined);
+    await store.upsertRejection('evt-3', 'circuit-open', undefined);
+    await store.upsertRejection('evt-3', 'circuit-open', 'still tripping');
+
+    const result = await requeue({ store, bus, eventId: 'evt-3' });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.attemptsBeforeRequeue).toBe(3);
+    }
+
+    db.close();
+  });
+});

--- a/packages/core/src/events/dlq.ts
+++ b/packages/core/src/events/dlq.ts
@@ -1,0 +1,116 @@
+/**
+ * Dispatch DLQ requeue helper.
+ *
+ * The DLQ state (slice 5 / PR 5.1) lives in the `rejected_events` table;
+ * the `EventStore.deleteRejection` + `listRejections` surface is read-
+ * only from the dispatcher's perspective. Active requeue — re-injecting
+ * a rejected event back onto the live bus — needs to be triggered from
+ * inside the `up` process (the only place the bus is in-memory and the
+ * dispatcher is wired). The control socket (§3 item #6 of the Enterprise
+ * Production Plan) exposes `dlq.requeue <id>` as a socket op; this helper
+ * is the one-line impl that op calls.
+ *
+ * Semantics:
+ *   1. Look up the rejection row. If absent → `dlq-miss` error.
+ *   2. Look up the original event row from `events`. If absent → `event-miss`.
+ *   3. Publish a cloned event onto `bus.publish()` — the dispatcher's
+ *      bus subscriber picks it up exactly like a fresh arrival.
+ *   4. Delete the rejection row on success so the DLQ only reflects
+ *      events currently stuck. The original event row (+ its outcome
+ *      history) stays in `events` unchanged — the rejection is still
+ *      the historical truth.
+ *
+ * Idempotence: the second call for the same id (after the first has
+ * already deleted the rejection row) returns `{ ok: false, reason:
+ * 'dlq-miss' }`. Never a silent duplicate-publish.
+ *
+ * @since 0.6.x
+ */
+
+import type { EventStore } from './store.js';
+import type { EventBus } from './types.js';
+
+export type RequeueRejectionReason =
+  /** The event id was never in the rejected_events table, or already requeued. */
+  | 'dlq-miss'
+  /** The event id was in the DLQ but the full event row has been vacuumed. */
+  | 'event-miss';
+
+export interface RequeueResultOk {
+  readonly ok: true;
+  readonly eventId: string;
+  readonly attemptsBeforeRequeue: number;
+}
+
+export interface RequeueResultErr {
+  readonly ok: false;
+  readonly eventId: string;
+  readonly reason: RequeueRejectionReason;
+  /** Free-form clarifier for the caller / CLI renderer. */
+  readonly message: string;
+}
+
+export type RequeueResult = RequeueResultOk | RequeueResultErr;
+
+export interface RequeueOptions {
+  readonly store: EventStore;
+  readonly bus: EventBus;
+  /** The DLQ event id to requeue. */
+  readonly eventId: string;
+}
+
+/**
+ * Requeue a single rejected event back onto the bus.
+ *
+ * Call flow:
+ *   store.getRejection   — find the DLQ ledger row
+ *   store.get            — find the original event body
+ *   bus.publish          — re-dispatch (dispatcher records a fresh outcome)
+ *   store.deleteRejection — acknowledge the DLQ row
+ *
+ * The deleteRejection happens AFTER the publish so a publish-throw doesn't
+ * leave the DLQ empty with no requeue done. If the publish itself succeeds
+ * but the new dispatch rejects again, the dispatcher's `upsertRejection`
+ * path re-inserts the row (with attempt_count bumped), which is the
+ * intended retry-ledger behavior.
+ */
+export async function requeue(opts: RequeueOptions): Promise<RequeueResult> {
+  const { store, bus, eventId } = opts;
+
+  const rejection = await store.getRejection(eventId);
+  if (!rejection) {
+    return {
+      ok: false,
+      eventId,
+      reason: 'dlq-miss',
+      message: `no dispatch DLQ entry for "${eventId}" — already requeued or never rejected`,
+    };
+  }
+
+  const record = await store.get(eventId);
+  if (!record) {
+    return {
+      ok: false,
+      eventId,
+      reason: 'event-miss',
+      message: `event "${eventId}" is in the DLQ but its body is no longer in the events table (vacuumed?)`,
+    };
+  }
+
+  // Re-publish onto the live bus. We intentionally publish the *same*
+  // event id so the dispatcher's idempotency cache sees this as a retry
+  // (not a fresh event). The outcome row on `events` will be overwritten
+  // by the new dispatch attempt's outcome.
+  await bus.publish(record.event);
+
+  // Delete the DLQ ledger row only after publish succeeds. If the
+  // re-dispatch rejects again, the dispatcher's own upsertRejection
+  // path will re-insert with attempt_count bumped.
+  await store.deleteRejection(eventId);
+
+  return {
+    ok: true,
+    eventId,
+    attemptsBeforeRequeue: rejection.attemptCount,
+  };
+}

--- a/packages/core/src/events/index.ts
+++ b/packages/core/src/events/index.ts
@@ -165,6 +165,14 @@ export type {
   EventStoreListFilter,
   EventStoreRecord,
 } from './store.js';
+export { requeue } from './dlq.js';
+export type {
+  RequeueOptions,
+  RequeueRejectionReason,
+  RequeueResult,
+  RequeueResultErr,
+  RequeueResultOk,
+} from './dlq.js';
 export {
   computeNextFire,
   createCronAdapter,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,28 @@ export const VERSION = '0.0.1';
 
 export type * from './types/index.js';
 export {
+  connectControlSocket,
+  controlSocketPath,
+  encodeControlSocketMessage,
+  handleControlSocketRequest,
+  isControlSocketRequest,
+  startControlSocket,
+} from './daemon/index.js';
+export type {
+  ControlSocketClient,
+  ControlSocketContext,
+  ControlSocketErrorBody,
+  ControlSocketOp,
+  ControlSocketReloadResult,
+  ControlSocketRequest,
+  ControlSocketRequestBase,
+  ControlSocketResponse,
+  ControlSocketResultByOp,
+  ControlSocketServer,
+  ControlSocketStatus,
+  StartControlSocketOptions,
+} from './daemon/index.js';
+export {
   DEFAULT_TENANT_CONTEXT,
   DEFAULT_TENANT_ID,
   QuotaExceededError,
@@ -251,6 +273,7 @@ export {
   frameEvent,
   handleControlRequest,
   hmacSha256Hex,
+  requeue,
   isControlRequest,
   listEventSources,
   parseCron,
@@ -347,6 +370,11 @@ export type {
   EventSourceTag,
   EventRejectionListFilter,
   EventRejectionRecord,
+  RequeueOptions,
+  RequeueRejectionReason,
+  RequeueResult,
+  RequeueResultErr,
+  RequeueResultOk,
   EventStore,
   EventStoreListFilter,
   EventStoreRecord,


### PR DESCRIPTION
## Summary
- Implements [Enterprise Production Plan §3 item #6](docs/ENTERPRISE_PRODUCTION_PLAN.md) — one control socket per agent at `~/.declaragent/<agent-id>/control.sock` (named pipe on Windows), JSON-RPC line protocol, 5 fixed ops: `ping`, `status`, `dlq.requeue`, `reload`, `shutdown`.
- Unblocks item #3 (Dispatch-DLQ active requeue) by shipping the `requeue()` helper in `packages/core/src/events/dlq.ts`. The CLI verb `declaragent dlq requeue` is still item #3's job — not in this PR.

## Files touched
- `packages/core/src/daemon/control-socket.ts` (new) — server + client, typed discriminated-union ops, 0600 perms, stale-socket unlink, auto-clean on close, honors `$HOME` for test isolation.
- `packages/core/src/daemon/control-socket.test.ts` (new) — 18 unit tests + real-socket round-trip tests (all 5 ops, concurrent correlation, malformed-request → `EBADREQ`, stale-socket rebind).
- `packages/core/src/events/dlq.ts` (new) — idempotent `requeue()` helper. Second call returns `{ok:false, reason:'dlq-miss'}` instead of silent re-dispatch.
- `packages/core/src/events/dlq.test.ts` (new) — 5 tests (happy path, dlq-miss, event-miss, idempotence, attempt-count carry).
- `packages/cli/src/up-cli.ts` — binds a socket per agent in `bringUp`, closes in `stopAll`, wildcard bus subscriber tracks `lastEventAt` for `status`. Socket-bind failure is non-fatal.
- `packages/cli/src/ps-cli.ts` — queries each agent's socket (500ms timeout) with the `up-state.json` snapshot as fallback.
- `packages/cli/src/up-control-socket.test.ts` (new) — integration test that spawns real `up`, exercises all 5 ops, asserts auto-clean on shutdown.

## Acceptance mapping (§3 #6)
1. ✅ `declaragent ps` now queries the socket with a state-file fallback.
2. ✅ `requeue()` helper ready; CLI verb is item #3.
3. ✅ Stale socket doesn't wedge next `up` — rebind test covers this.

## Known deferrals
- **`reload` op** currently returns `{reloaded:false, reason:'unsupported'}`. A real hot-reload needs (a) diffing `agent.yaml#skills` + `event-sources.yaml` + `channels.json` against live state, (b) swapping sources without dropping in-flight events. Tracked as a follow-up so this PR stays scoped.
- **`status.agents[].pid`** is the parent `up` process pid. Fleet members sharing one process all report the same pid. If #5 (control plane) wants per-agent pids, it'll need its own process model.

## Test plan
- [x] `bun run typecheck` — all packages green
- [x] `bun run lint` — clean
- [x] `bun run build` — all 13 packages built
- [x] `bun test packages/core/src/daemon packages/core/src/events/dlq.test.ts packages/cli/src/up-cli.test.ts packages/cli/src/up-control-socket.test.ts` — 38 pass / 0 fail
- [x] `bun test` (repo-wide) — 2345 pass / 23 skip / 4 pre-existing `loadPlugin (fixture)` failures unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)