### PR TITLE
feat(plugin-agent-rpc,core): OIDC + OAuth2 Client-Credentials auth (#4)

### DIFF
--- a/docs-site/docs/reference/rpc.mdx
+++ b/docs-site/docs/reference/rpc.mdx
@@ -291,6 +291,8 @@ declaragent rpc capabilities       # print this agent's capabilities
 | --- | --- |
 | `auth: { kind: 'internal' }` | Intra-cluster deployments that trust the bus scope + broker ACLs. Default. |
 | `auth: { kind: 'hmac', keyId, signature }` | Shared-secret envelope integrity. Receiver canonicalizes via `canonicalizeForSigning` and compares SHA-256. |
+| `auth: { kind: 'oidc', token, keyId? }` | Bearer JWT from an enterprise OIDC IdP (Okta / Azure AD / Auth0 / Dex). Verified against a cached JWKS. |
+| `auth: { kind: 'oauth2-client', token, scope? }` | OAuth2 Client-Credentials access token. For service-to-service calls where no user is present. |
 
 Agents that require signed envelopes declare it in `agent.yaml`:
 
@@ -301,8 +303,93 @@ rpc:
     keysRef: ${secret:vault:kv/acme/rpc-keys}
 ```
 
-mTLS / JWT / SPIFFE are transport-layer concerns — each transport
-plugin exposes a `validateAuth(envelope, raw, transportCtx)` hook.
+mTLS / SPIFFE are transport-layer concerns — each transport plugin
+exposes a `validateAuth(envelope, raw, transportCtx)` hook.
+
+### Authenticated RPC (OIDC / OAuth2) — since 1.2.0
+
+Enterprise deployments usually require every inter-agent RPC to carry a
+verifiable bearer token rather than relying on trusted-network
+assumptions. Declaragent ships two providers for this:
+
+- **OIDC** (`@declaragent/plugin-agent-rpc` → `createOidcAuthProvider`)
+  — validates a JWT signed by an OIDC issuer's JWKS. Supports
+  `RS{256,384,512}`, `PS{256,384,512}`, `ES{256,384,512}`. `alg: none`
+  is always rejected. JWKS is fetched from
+  `/.well-known/openid-configuration` (or a pinned `jwksUri`) and
+  cached for 5 minutes.
+- **OAuth2 Client-Credentials** (`createOAuth2ClientAuthProvider`) —
+  mints an access token via `grant_type=client_credentials`, caches it
+  until `expires_in - 30s`, and verifies incoming tokens via the same
+  JWKS path.
+
+Configure a receiver's peer with an `auth` block in `rpc-peers.yaml`:
+
+```yaml
+version: 1
+peers:
+  - agent: agent://peer-b
+    transports:
+      - kind: kafka
+        brokers: ["kafka.internal:9092"]
+        topics: { requests: agents.peer-b.requests }
+    auth:
+      provider: oidc
+      issuer: "https://dex.example.com"
+      audience: "declaragent-peer-b"
+      jwksUri: "https://dex.example.com/keys"   # optional; derived from issuer when omitted
+      scopes: ["rpc:invoke"]                    # strict AND — every scope must be present
+  - agent: agent://peer-c
+    transports:
+      - kind: kafka
+        brokers: ["kafka.internal:9092"]
+        topics: { requests: agents.peer-c.requests }
+    auth:
+      provider: oauth2-client
+      tokenEndpoint: "https://idp.example.com/oauth2/token"
+      clientId: "decl-agent-a"
+      clientSecretRef: "secret://platform/decl-agent-a-client-secret"
+      scopes: ["rpc:invoke"]
+```
+
+**Rejection semantics.** Envelopes that fail verify are routed to the
+local DLQ under `kind=auth-rejected` with a typed reason code:
+
+- `missing-auth` — envelope has no `auth` block.
+- `wrong-kind` — `auth.kind` doesn't match the peer's configured
+  provider.
+- `malformed-token` — JWT parse failed.
+- `alg-none` — token advertised `alg: none`.
+- `expired` / `not-yet-valid` — outside `exp`/`iat`/`nbf` with a 60s
+  clock-skew tolerance.
+- `wrong-issuer` / `wrong-audience` — claim mismatch.
+- `insufficient-scope` — one or more required scopes missing.
+- `idp-unreachable` — JWKS fetch failed AND cache is empty / expired.
+  Fail-closed — we never admit a token we can't verify.
+- `bad-signature` — JWKS signature verify failed.
+
+**Audit.** Every verify decision (accept or reject) emits an
+`auth_check` record on the hash-chained audit log. Inspect via
+`declaragent audit list --kind auth_check`; each row carries
+`peerId`, `provider`, `decision`, `subject` (when accepted), and
+`reason` (when rejected).
+
+**Secret handling.** `clientSecretRef` is resolved through the
+Declaragent secret pipeline (`secret://`, `vault:`, `aws-sm:`, …).
+The raw value is never inlined into the config or logged.
+
+**Operational notes.**
+
+- JWKS is cached for 5 minutes. Graceful stale-fallback during IdP
+  outage is a follow-up; the current policy fails closed if the cache
+  expires while the IdP is unreachable.
+- Tokens are bound to the peer, not to envelope content, so HMAC
+  canonicalization (`canonicalizeForSigning`) continues to exclude the
+  `auth` field. Rotating a token does not invalidate any in-flight
+  envelopes.
+- Unit coverage: `packages/plugin-agent-rpc/src/auth/oidc.test.ts`
+  and `oauth2-client.test.ts`. Integration: `packages/testkit/src/fleet-integration/rpc-auth.test.ts`
+  (gated by `RPC_AUTH_INTEGRATION=1`, uses `dex` under docker-compose).
 
 ## Error codes
 

--- a/packages/core/src/audit/index.ts
+++ b/packages/core/src/audit/index.ts
@@ -1,4 +1,5 @@
 export type {
+  AuthCheckAuditRecord,
   EraseOptions,
   ErasedAuditRecord,
   QuotaExceededAuditRecord,

--- a/packages/core/src/audit/types.ts
+++ b/packages/core/src/audit/types.ts
@@ -80,6 +80,30 @@ export interface QuotaExceededAuditRecord {
 }
 
 /**
+ * RPC auth verify outcome. One record per inbound envelope — whether
+ * accepted or rejected — so operators can audit authentication decisions
+ * on the hash chain.
+ *
+ * @since 1.2.0
+ */
+export interface AuthCheckAuditRecord {
+  kind: 'auth_check';
+  ts: number;
+  tenantId: string;
+  /** Logical peer address (`agent://...`) of the sender. */
+  peerId: string;
+  /** Auth provider that made the decision. `none` when envelope lacked an auth block. */
+  provider: 'oidc' | 'oauth2-client' | 'hmac' | 'internal' | 'none';
+  decision: 'accept' | 'reject';
+  /** Typed rejection reason; absent on `accept`. */
+  reason?: string;
+  /** RPC correlation id of the originating envelope, for cross-referencing. */
+  correlationId?: string;
+  /** Resolved principal subject when the decision is `accept` and a JWT was parsed. */
+  subject?: string;
+}
+
+/**
  * Erasure tombstone — surfaced by queries in place of records that
  * `TenantAuditSink.erase()` has scrubbed. Keeps the hash-chain verifier
  * able to confirm continuity even after right-to-erasure requests.
@@ -113,6 +137,7 @@ export type TenantAuditRecord =
   | SecretAccessAuditRecord
   | TenantBoundaryAuditRecord
   | QuotaExceededAuditRecord
+  | AuthCheckAuditRecord
   | ErasedAuditRecord;
 
 /** @since 1.0.0 */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -111,6 +111,7 @@ export {
   verifyEntries as verifyAuditEntries,
 } from './audit/index.js';
 export type {
+  AuthCheckAuditRecord,
   CreateSqliteAuditSinkOptions,
   EraseByCorrelationOptions,
   EraseBySessionOptions,
@@ -828,6 +829,7 @@ export {
   parseCapabilitiesConfig,
   parseEnvelope,
   parsePeersConfig,
+  peerAuthSchema,
   peersConfigSchema,
   resolvePeerTransport,
 } from './rpc/index.js';
@@ -841,6 +843,7 @@ export type {
   EnvelopeKind,
   LoadedCapabilities,
   LoadedPeers,
+  PeerAuthConfig,
   PeerEntry,
   PeerTransport,
   PeersConfig,

--- a/packages/core/src/rpc/envelope.test.ts
+++ b/packages/core/src/rpc/envelope.test.ts
@@ -101,6 +101,53 @@ describe('AgentRpcEnvelope', () => {
     ).toThrow(RpcEnvelopeValidationError);
   });
 
+  test('oidc auth accepts token + optional keyId (Item #4)', () => {
+    expect(() =>
+      parseEnvelope({
+        ...baseRequest(),
+        auth: { kind: 'oidc', token: 'eyJhbGciOi.eyJpc3Mi.sig' },
+      }),
+    ).not.toThrow();
+
+    expect(() =>
+      parseEnvelope({
+        ...baseRequest(),
+        auth: { kind: 'oidc', token: 'tok', keyId: 'kid-1' },
+      }),
+    ).not.toThrow();
+
+    expect(() =>
+      parseEnvelope({
+        ...baseRequest(),
+        auth: { kind: 'oidc', token: '' } as never,
+      }),
+    ).toThrow(RpcEnvelopeValidationError);
+  });
+
+  test('oauth2-client auth accepts token + optional scope (Item #4)', () => {
+    expect(() =>
+      parseEnvelope({
+        ...baseRequest(),
+        auth: { kind: 'oauth2-client', token: 'eyJ.eyJ.sig' },
+      }),
+    ).not.toThrow();
+
+    expect(() =>
+      parseEnvelope({
+        ...baseRequest(),
+        auth: { kind: 'oauth2-client', token: 't', scope: 'rpc:invoke' },
+      }),
+    ).not.toThrow();
+  });
+
+  test('canonicalizeForSigning still omits auth for new variants', () => {
+    const env = baseRequest({
+      auth: { kind: 'oidc', token: 'eyJ.eyJ.sig' },
+    });
+    expect(canonicalizeForSigning(env)).not.toContain('"auth"');
+    expect(canonicalizeForSigning(env)).not.toContain('"token"');
+  });
+
   test('canonicalizeForSigning omits auth and orders keys deterministically', () => {
     const env = baseRequest({
       auth: { kind: 'hmac', keyId: 'k1', signature: 'sig' },

--- a/packages/core/src/rpc/envelope.ts
+++ b/packages/core/src/rpc/envelope.ts
@@ -21,12 +21,29 @@ export type BrokerAddress =
   | `memory://${string}`;
 
 /**
- * Envelope authenticator. `internal` is the default for intra-cluster
- * deployments that trust the bus scope. `hmac` opts in to shared-secret
- * signing — the canonical envelope form (minus the `auth` field) is
- * hashed with SHA-256 and compared on the receiver.
+ * Envelope authenticator.
+ *
+ *   - `internal`       — intra-cluster trust, no crypto.
+ *   - `hmac`           — shared-secret signing over the canonical envelope
+ *                        form (see {@link canonicalizeForSigning}).
+ *   - `oidc`           — bearer JWT issued by an OIDC IdP, verified against
+ *                        a cached JWKS on the receiver (see
+ *                        `@declaragent/plugin-agent-rpc/auth/oidc`).
+ *   - `oauth2-client`  — bearer access token minted via OAuth2
+ *                        Client-Credentials. Verified the same way as OIDC.
+ *
+ * Soft-compat within `version: 1`: receivers that don't recognise one of
+ * the additive variants fail envelope decode and the transport routes
+ * the message to the local DLQ — no silent accept.
+ *
+ * @since 1.1.0 — `internal`, `hmac`
+ * @since 1.2.0 — `oidc`, `oauth2-client`
  */
-export type RpcAuth = { kind: 'internal' } | { kind: 'hmac'; keyId: string; signature: string };
+export type RpcAuth =
+  | { kind: 'internal' }
+  | { kind: 'hmac'; keyId: string; signature: string }
+  | { kind: 'oidc'; token: string; keyId?: string }
+  | { kind: 'oauth2-client'; token: string; scope?: string };
 
 /** Typed error body used on `response` envelopes with `status !== 'ok'`. */
 export interface RpcError {
@@ -88,6 +105,16 @@ const RpcAuthSchema = z.union([
     kind: z.literal('hmac'),
     keyId: z.string().min(1),
     signature: z.string().min(1),
+  }),
+  z.object({
+    kind: z.literal('oidc'),
+    token: z.string().min(1),
+    keyId: z.string().min(1).optional(),
+  }),
+  z.object({
+    kind: z.literal('oauth2-client'),
+    token: z.string().min(1),
+    scope: z.string().min(1).optional(),
   }),
 ]);
 

--- a/packages/core/src/rpc/index.ts
+++ b/packages/core/src/rpc/index.ts
@@ -45,11 +45,13 @@ export {
   PeersConfigError,
   loadPeersConfig,
   parsePeersConfig,
+  peerAuthSchema,
   peersConfigSchema,
   resolvePeerTransport,
 } from './peers-loader.js';
 export type {
   LoadedPeers,
+  PeerAuthConfig,
   PeerEntry,
   PeerTransport,
   PeersConfig,

--- a/packages/core/src/rpc/peers-loader.test.ts
+++ b/packages/core/src/rpc/peers-loader.test.ts
@@ -95,3 +95,98 @@ describe('resolvePeerTransport', () => {
     expect(resolved?.address).toBe('memory://agents.local.requests');
   });
 });
+
+describe('parsePeersConfig — per-peer auth (Item #4)', () => {
+  test('accepts an OIDC auth block', () => {
+    const loaded = parsePeersConfig({
+      version: 1,
+      peers: [
+        {
+          agent: 'agent://peer-a',
+          transports: [{ kind: 'memory', topics: { requests: 'agents.peer-a.requests' } }],
+          auth: {
+            provider: 'oidc',
+            issuer: 'https://dex.example.com',
+            audience: 'declaragent-peer-a',
+            jwksUri: 'https://dex.example.com/keys',
+            scopes: ['rpc:invoke'],
+          },
+        },
+      ],
+    });
+    const entry = loaded.byAgent.get('agent://peer-a');
+    expect(entry?.auth?.provider).toBe('oidc');
+  });
+
+  test('accepts an OAuth2 Client-Credentials auth block with secret ref', () => {
+    const loaded = parsePeersConfig({
+      version: 1,
+      peers: [
+        {
+          agent: 'agent://peer-b',
+          transports: [{ kind: 'memory', topics: { requests: 'agents.peer-b.requests' } }],
+          auth: {
+            provider: 'oauth2-client',
+            tokenEndpoint: 'https://idp.example.com/oauth2/token',
+            clientId: 'decl-agent-a',
+            clientSecretRef: 'secret://platform/decl-agent-a-client-secret',
+            scopes: ['rpc:invoke'],
+          },
+        },
+      ],
+    });
+    const entry = loaded.byAgent.get('agent://peer-b');
+    expect(entry?.auth?.provider).toBe('oauth2-client');
+    if (entry?.auth?.provider === 'oauth2-client') {
+      expect(entry.auth.clientSecretRef).toBe('secret://platform/decl-agent-a-client-secret');
+    }
+  });
+
+  test('rejects unknown auth provider', () => {
+    expect(() =>
+      parsePeersConfig({
+        version: 1,
+        peers: [
+          {
+            agent: 'agent://peer-c',
+            transports: [{ kind: 'memory', topics: { requests: 'agents.peer-c.requests' } }],
+            auth: { provider: 'saml', foo: 'bar' },
+          },
+        ],
+      }),
+    ).toThrow(PeersConfigError);
+  });
+
+  test('rejects OAuth2 block missing clientSecretRef', () => {
+    expect(() =>
+      parsePeersConfig({
+        version: 1,
+        peers: [
+          {
+            agent: 'agent://peer-d',
+            transports: [{ kind: 'memory', topics: { requests: 'agents.peer-d.requests' } }],
+            auth: {
+              provider: 'oauth2-client',
+              tokenEndpoint: 'https://idp.example.com/oauth2/token',
+              clientId: 'c',
+            },
+          },
+        ],
+      }),
+    ).toThrow(PeersConfigError);
+  });
+
+  test('no auth block is allowed (legacy)', () => {
+    const loaded = parsePeersConfig({
+      version: 1,
+      peers: [
+        {
+          agent: 'agent://peer-e',
+          transports: [{ kind: 'memory', topics: { requests: 'agents.peer-e.requests' } }],
+        },
+      ],
+    });
+    const entry = loaded.byAgent.get('agent://peer-e');
+    expect(entry?.auth).toBeUndefined();
+  });
+});

--- a/packages/core/src/rpc/peers-loader.ts
+++ b/packages/core/src/rpc/peers-loader.ts
@@ -100,10 +100,55 @@ const peerTransportSchema = z.discriminatedUnion('kind', [
   memoryPeerTransport,
 ]);
 
+/**
+ * Per-peer authentication config. Optional — absent = legacy
+ * `internal`/`hmac` envelope auth. When present, incoming envelopes
+ * from this peer MUST carry a matching {@link RpcAuth.kind} and pass
+ * provider-side verify. See `@declaragent/plugin-agent-rpc/auth/*`
+ * for the provider implementations.
+ *
+ * @since 1.2.0
+ */
+const oidcPeerAuthSchema = z
+  .object({
+    provider: z.literal('oidc'),
+    issuer: z.string().min(1),
+    audience: z.string().min(1),
+    jwksUri: z.string().min(1).optional(),
+    scopes: z.array(z.string().min(1)).optional(),
+  })
+  .strict();
+
+const oauth2ClientPeerAuthSchema = z
+  .object({
+    provider: z.literal('oauth2-client'),
+    tokenEndpoint: z.string().min(1),
+    clientId: z.string().min(1),
+    /**
+     * Resolver reference (e.g. `secret://platform/client-secret`). The
+     * secret is pulled through the Phase-6 secret-resolver pipeline at
+     * runtime, never inlined into the config.
+     */
+    clientSecretRef: z.string().min(1),
+    jwksUri: z.string().min(1).optional(),
+    issuer: z.string().min(1).optional(),
+    audience: z.string().min(1).optional(),
+    scopes: z.array(z.string().min(1)).optional(),
+  })
+  .strict();
+
+export const peerAuthSchema = z.discriminatedUnion('provider', [
+  oidcPeerAuthSchema,
+  oauth2ClientPeerAuthSchema,
+]);
+
+export type PeerAuthConfig = z.infer<typeof peerAuthSchema>;
+
 const peerEntrySchema = z
   .object({
     agent: z.string().regex(/^agent:\/\/.+/, 'agent must be `agent://<id>`'),
     transports: z.array(peerTransportSchema).min(1),
+    auth: peerAuthSchema.optional(),
   })
   .strict();
 

--- a/packages/plugin-agent-rpc/src/agent-inbox.test.ts
+++ b/packages/plugin-agent-rpc/src/agent-inbox.test.ts
@@ -189,4 +189,153 @@ describe('agent-inbox adapter', () => {
     } as unknown as AgentRpcEnvelope);
     await instance.stop();
   });
+
+  test('auth registry rejects envelopes + routes to reject sink (Item #4)', async () => {
+    const transport = createMemoryTransport();
+    const deps = baseDeps();
+    const published: AgentEvent[] = [];
+    deps.bus.subscribe('*', (ev) => {
+      published.push(ev);
+    });
+
+    const rejects: { reason: string; from: string }[] = [];
+    const audits: { decision: string; reason?: string; subject?: string }[] = [];
+
+    const instance = await createAgentInboxAdapter({
+      transport,
+      authRegistry: {
+        resolve() {
+          return {
+            config: {
+              provider: 'oidc' as const,
+              issuer: 'https://dex.example.com',
+              audience: 'aud',
+            },
+            provider: {
+              name: 'oidc' as const,
+              async sign() {
+                return { kind: 'oidc', token: 'tok' };
+              },
+              async verify() {
+                return { ok: false, reason: 'expired', message: 'token expired' } as const;
+              },
+            },
+          };
+        },
+      },
+      authRejectSink: ({ envelope, reason }) => {
+        rejects.push({ reason, from: envelope.from });
+      },
+      auditSink: {
+        async record(r) {
+          if (r.kind === 'auth_check') {
+            const row: { decision: string; reason?: string; subject?: string } = {
+              decision: r.decision,
+            };
+            if (r.reason !== undefined) row.reason = r.reason;
+            if (r.subject !== undefined) row.subject = r.subject;
+            audits.push(row);
+          }
+        },
+        async query() {
+          return [];
+        },
+        async erase() {
+          return 0;
+        },
+        async verify() {
+          return { ok: true, totalEntries: 0, verifiedEntries: 0, violations: [] };
+        },
+        async prune() {
+          return 0;
+        },
+        close() {},
+      },
+    }).create({ id: 'inbox', agentId: 'pr-reviewer' }, deps);
+    await instance.start();
+    await transport.publish('agents.pr-reviewer.requests', {
+      ...requestEnvelope(),
+      auth: { kind: 'oidc', token: 'expired-token' },
+    });
+    expect(published).toHaveLength(0);
+    expect(rejects).toHaveLength(1);
+    expect(rejects[0]?.reason).toBe('expired');
+    expect(audits).toHaveLength(1);
+    expect(audits[0]?.decision).toBe('reject');
+    expect(audits[0]?.reason).toBe('expired');
+    await instance.stop();
+  });
+
+  test('auth registry accepts + emits an auth_check=accept record (Item #4)', async () => {
+    const transport = createMemoryTransport();
+    const deps = baseDeps();
+    const published: AgentEvent[] = [];
+    deps.bus.subscribe('*', (ev) => {
+      published.push(ev);
+    });
+    const audits: { decision: string; subject?: string }[] = [];
+    const instance = await createAgentInboxAdapter({
+      transport,
+      authRegistry: {
+        resolve() {
+          return {
+            config: {
+              provider: 'oidc' as const,
+              issuer: 'https://dex.example.com',
+              audience: 'aud',
+            },
+            provider: {
+              name: 'oidc' as const,
+              async sign() {
+                return { kind: 'oidc', token: 't' };
+              },
+              async verify() {
+                return {
+                  ok: true,
+                  principal: {
+                    subject: 'peer-a',
+                    issuer: 'https://dex.example.com',
+                    audience: 'aud',
+                    scopes: ['rpc:invoke'],
+                    claims: {},
+                  },
+                } as const;
+              },
+            },
+          };
+        },
+      },
+      auditSink: {
+        async record(r) {
+          if (r.kind === 'auth_check') {
+            const row: { decision: string; subject?: string } = { decision: r.decision };
+            if (r.subject !== undefined) row.subject = r.subject;
+            audits.push(row);
+          }
+        },
+        async query() {
+          return [];
+        },
+        async erase() {
+          return 0;
+        },
+        async verify() {
+          return { ok: true, totalEntries: 0, verifiedEntries: 0, violations: [] };
+        },
+        async prune() {
+          return 0;
+        },
+        close() {},
+      },
+    }).create({ id: 'inbox', agentId: 'pr-reviewer' }, deps);
+    await instance.start();
+    await transport.publish('agents.pr-reviewer.requests', {
+      ...requestEnvelope(),
+      auth: { kind: 'oidc', token: 'valid' },
+    });
+    expect(published).toHaveLength(1);
+    expect(audits).toHaveLength(1);
+    expect(audits[0]).toEqual({ decision: 'accept', subject: 'peer-a' });
+    await instance.stop();
+  });
 });

--- a/packages/plugin-agent-rpc/src/agent-inbox.ts
+++ b/packages/plugin-agent-rpc/src/agent-inbox.ts
@@ -18,17 +18,41 @@
 import {
   type AgentEvent,
   type AgentRpcEnvelope,
+  type AuthCheckAuditRecord,
   type BrokerAddress,
   type EventSourceAdapter,
   type EventSourceInstance,
+  type PeerAuthConfig,
   type RpcSubscriptionHandler,
   type RpcTransport,
   type SourceDependencies,
   type SourceHealth,
   type SourceMetrics,
+  type TenantAuditSink,
   decodeEnvelope,
 } from '@declaragent/core';
+import type { RpcAuthProvider, RpcAuthRejectReason } from './auth/types.js';
 import type { PendingRegistry } from './pending-registry.js';
+
+/**
+ * Callback invoked when an envelope fails auth verify. Receivers wire
+ * this to the event-store's `upsertRejection` so the envelope lands on
+ * the `rejected_events` table under `kind=auth-rejected`.
+ */
+export type AuthRejectSink = (entry: {
+  envelope: AgentRpcEnvelope;
+  reason: RpcAuthRejectReason;
+  message: string;
+}) => Promise<void> | void;
+
+/**
+ * Map from `agent://` peer id to its verify config + the provider that
+ * knows how to verify it. Receivers look up by `envelope.from`.
+ */
+export interface AuthVerifyRegistry {
+  /** Return verify config for this peer, or `undefined` when auth is not required. */
+  resolve(peerId: string): { config: PeerAuthConfig; provider: RpcAuthProvider } | undefined;
+}
 
 export interface AgentInboxConfig {
   id: string;
@@ -63,6 +87,29 @@ export interface CreateAgentInboxAdapterOptions {
    * default hook publishes an `AgentEvent` with `target: { type: 'broadcast' }`.
    */
   onEvent?(envelope: AgentRpcEnvelope, event: AgentEvent): Promise<void> | void;
+  /**
+   * Per-peer auth registry. When present, every inbound envelope is
+   * verified against the registered {@link RpcAuthProvider}. Peers
+   * without an entry remain on the legacy `internal`/`hmac` path
+   * (envelope passes through unchanged).
+   *
+   * @since 1.2.0
+   */
+  authRegistry?: AuthVerifyRegistry;
+  /**
+   * Sink for auth-rejected envelopes. Receivers wire this to
+   * `EventStore.upsertRejection` so rejects land in `rejected_events`
+   * under `kind=auth-rejected`.
+   */
+  authRejectSink?: AuthRejectSink;
+  /**
+   * Audit sink for `auth_check` records. One record is emitted per
+   * envelope — accept OR reject — so operators can audit authentication
+   * decisions on the hash chain.
+   */
+  auditSink?: TenantAuditSink;
+  /** Injected clock for audit record timestamps. */
+  now?(): number;
 }
 
 interface AgentInboxMetrics {
@@ -71,6 +118,8 @@ interface AgentInboxMetrics {
   failed: number;
   dlq: number;
   tenantRejects: number;
+  authAccepted: number;
+  authRejected: number;
   responsesMatched: number;
   responsesStale: number;
   lastMessageAt: number | null;
@@ -116,6 +165,8 @@ class AgentInboxInstance implements EventSourceInstance {
     failed: 0,
     dlq: 0,
     tenantRejects: 0,
+    authAccepted: 0,
+    authRejected: 0,
     responsesMatched: 0,
     responsesStale: 0,
     lastMessageAt: null,
@@ -212,6 +263,15 @@ class AgentInboxInstance implements EventSourceInstance {
       return;
     }
 
+    // Auth verify (Item #4). Only runs for peers the registry knows about;
+    // peers without a registered provider fall back to the legacy path.
+    if (this.opts.authRegistry) {
+      const authOk = await this.verifyAuth(envelope);
+      if (!authOk) return;
+    } else {
+      await this.emitAuthCheck(envelope, 'accept', envelope.auth?.kind ?? 'none');
+    }
+
     try {
       switch (envelope.kind) {
         case 'request':
@@ -231,6 +291,119 @@ class AgentInboxInstance implements EventSourceInstance {
         id: this.id,
         topic,
         messageId: envelope.messageId,
+        err: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
+   * Returns `true` when the envelope passes auth verify (including the
+   * no-registry-entry fallback), `false` when rejected. Rejected
+   * envelopes are dispatched to the reject sink + increment the
+   * authRejected metric.
+   */
+  private async verifyAuth(envelope: AgentRpcEnvelope): Promise<boolean> {
+    const registry = this.opts.authRegistry;
+    if (!registry) {
+      await this.emitAuthCheck(envelope, 'accept', envelope.auth?.kind ?? 'none');
+      return true;
+    }
+    const entry = registry.resolve(envelope.from);
+    if (!entry) {
+      // Peer not registered → fall through to legacy path. We still
+      // emit an accept audit record so ops can see which peers bypass.
+      await this.emitAuthCheck(envelope, 'accept', envelope.auth?.kind ?? 'none');
+      return true;
+    }
+    const { config, provider } = entry;
+    try {
+      const result = await provider.verify(
+        envelope,
+        // The provider contract is parameterised on its own peer config
+        // shape; at the registry boundary we just hand the discriminated
+        // union through. Each provider's verify narrows by `provider.name`.
+        config as unknown as Parameters<typeof provider.verify>[1],
+      );
+      if (result.ok) {
+        this.metrics_.authAccepted += 1;
+        await this.emitAuthCheck(envelope, 'accept', provider.name, result.principal.subject);
+        return true;
+      }
+      this.metrics_.authRejected += 1;
+      this.deps.logger.warn('agent-inbox.auth-rejected', {
+        id: this.id,
+        from: envelope.from,
+        provider: provider.name,
+        reason: result.reason,
+        messageId: envelope.messageId,
+      });
+      await this.emitAuthCheck(envelope, 'reject', provider.name, undefined, result.reason);
+      if (this.opts.authRejectSink) {
+        try {
+          await this.opts.authRejectSink({
+            envelope,
+            reason: result.reason,
+            message: result.message,
+          });
+        } catch (err) {
+          this.deps.logger.error('agent-inbox.auth-reject-sink-error', {
+            id: this.id,
+            err: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+      return false;
+    } catch (err) {
+      this.metrics_.authRejected += 1;
+      const message = err instanceof Error ? err.message : String(err);
+      this.deps.logger.error('agent-inbox.auth-verify-error', {
+        id: this.id,
+        from: envelope.from,
+        provider: provider.name,
+        err: message,
+        messageId: envelope.messageId,
+      });
+      await this.emitAuthCheck(envelope, 'reject', provider.name, undefined, 'idp-unreachable');
+      if (this.opts.authRejectSink) {
+        try {
+          await this.opts.authRejectSink({
+            envelope,
+            reason: 'idp-unreachable',
+            message,
+          });
+        } catch {
+          // already logged
+        }
+      }
+      return false;
+    }
+  }
+
+  private async emitAuthCheck(
+    envelope: AgentRpcEnvelope,
+    decision: 'accept' | 'reject',
+    provider: AuthCheckAuditRecord['provider'],
+    subject?: string,
+    reason?: string,
+  ): Promise<void> {
+    if (!this.opts.auditSink) return;
+    const now = this.opts.now ?? Date.now;
+    const record: AuthCheckAuditRecord = {
+      kind: 'auth_check',
+      ts: now(),
+      tenantId: envelope.tenantId ?? this.deps.tenant?.id ?? 'default',
+      peerId: envelope.from,
+      provider,
+      decision,
+      correlationId: envelope.correlationId,
+    };
+    if (reason !== undefined) record.reason = reason;
+    if (subject !== undefined && subject.length > 0) record.subject = subject;
+    try {
+      await this.opts.auditSink.record(record);
+    } catch (err) {
+      this.deps.logger.error('agent-inbox.audit-sink-error', {
+        id: this.id,
         err: err instanceof Error ? err.message : String(err),
       });
     }

--- a/packages/plugin-agent-rpc/src/auth/jwt.ts
+++ b/packages/plugin-agent-rpc/src/auth/jwt.ts
@@ -1,0 +1,287 @@
+/**
+ * Minimal JWT verification primitives. Enough to verify RS256 / RS384 /
+ * RS512 / ES256 / ES384 / ES512 / PS256 / PS384 / PS512 tokens against a
+ * JWKS. Deliberately pins {@link SUPPORTED_ALGS} — `alg: none`, HS*, and
+ * any other asymmetric alg family must be rejected by callers.
+ *
+ * We roll our own instead of pulling in `jose` to avoid growing the
+ * plugin's dep surface for two narrow code paths. WebCrypto is in the
+ * runtime (Bun, Node ≥18) and covers every alg an OIDC IdP realistically
+ * issues.
+ *
+ * @since 1.2.0
+ */
+
+export class JwtError extends Error {
+  readonly code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'JwtError';
+    this.code = code;
+  }
+}
+
+export interface JwtHeader {
+  alg: string;
+  kid?: string;
+  typ?: string;
+  [k: string]: unknown;
+}
+
+export interface JwtClaims {
+  iss?: string;
+  aud?: string | string[];
+  sub?: string;
+  exp?: number;
+  iat?: number;
+  nbf?: number;
+  scope?: string;
+  scp?: string | string[];
+  [k: string]: unknown;
+}
+
+export interface DecodedJwt {
+  readonly header: JwtHeader;
+  readonly claims: JwtClaims;
+  readonly signingInput: string;
+  readonly signature: Uint8Array;
+}
+
+/** JWKS `keys` entry — we only care about fields we consume. */
+export interface JwkKey {
+  kid?: string;
+  kty: string;
+  alg?: string;
+  use?: string;
+  n?: string;
+  e?: string;
+  crv?: string;
+  x?: string;
+  y?: string;
+  [k: string]: unknown;
+}
+
+export const SUPPORTED_ALGS = new Set([
+  'RS256',
+  'RS384',
+  'RS512',
+  'ES256',
+  'ES384',
+  'ES512',
+  'PS256',
+  'PS384',
+  'PS512',
+]);
+
+export function b64urlDecode(input: string): Uint8Array {
+  // Pad + translate.
+  const pad = input.length % 4 === 0 ? '' : '='.repeat(4 - (input.length % 4));
+  const b64 = (input + pad).replace(/-/g, '+').replace(/_/g, '/');
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i += 1) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+function decodeJson(bytes: Uint8Array): unknown {
+  return JSON.parse(new TextDecoder().decode(bytes));
+}
+
+/**
+ * Decode a compact JWT into its three parts. No signature verification —
+ * that's {@link verifyJwtSignature}.
+ */
+export function decodeJwt(token: string): DecodedJwt {
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    throw new JwtError('malformed-token', 'JWT must have three dot-separated parts');
+  }
+  const [hPart, cPart, sPart] = parts as [string, string, string];
+  let header: JwtHeader;
+  let claims: JwtClaims;
+  try {
+    header = decodeJson(b64urlDecode(hPart)) as JwtHeader;
+    claims = decodeJson(b64urlDecode(cPart)) as JwtClaims;
+  } catch (err) {
+    throw new JwtError(
+      'malformed-token',
+      `JWT header/claims JSON decode failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (!header || typeof header !== 'object' || typeof header.alg !== 'string') {
+    throw new JwtError('malformed-token', 'JWT header missing `alg`');
+  }
+  const signature = b64urlDecode(sPart);
+  return {
+    header,
+    claims,
+    signingInput: `${hPart}.${cPart}`,
+    signature,
+  };
+}
+
+// WebCrypto param shapes. Project tsconfig's `lib` omits `dom`, so we
+// inline structural typings rather than reaching for the global ones.
+interface WcImportAlg {
+  name: string;
+  hash?: string;
+  namedCurve?: string;
+}
+interface WcVerifyAlg {
+  name: string;
+  hash?: string;
+  saltLength?: number;
+}
+
+function algToImport(alg: string): { importAlg: WcImportAlg; verifyAlg: WcVerifyAlg } {
+  switch (alg) {
+    case 'RS256':
+      return {
+        importAlg: { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+        verifyAlg: { name: 'RSASSA-PKCS1-v1_5' },
+      };
+    case 'RS384':
+      return {
+        importAlg: { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-384' },
+        verifyAlg: { name: 'RSASSA-PKCS1-v1_5' },
+      };
+    case 'RS512':
+      return {
+        importAlg: { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-512' },
+        verifyAlg: { name: 'RSASSA-PKCS1-v1_5' },
+      };
+    case 'PS256':
+      return {
+        importAlg: { name: 'RSA-PSS', hash: 'SHA-256' },
+        verifyAlg: { name: 'RSA-PSS', saltLength: 32 },
+      };
+    case 'PS384':
+      return {
+        importAlg: { name: 'RSA-PSS', hash: 'SHA-384' },
+        verifyAlg: { name: 'RSA-PSS', saltLength: 48 },
+      };
+    case 'PS512':
+      return {
+        importAlg: { name: 'RSA-PSS', hash: 'SHA-512' },
+        verifyAlg: { name: 'RSA-PSS', saltLength: 64 },
+      };
+    case 'ES256':
+      return {
+        importAlg: { name: 'ECDSA', namedCurve: 'P-256' },
+        verifyAlg: { name: 'ECDSA', hash: 'SHA-256' },
+      };
+    case 'ES384':
+      return {
+        importAlg: { name: 'ECDSA', namedCurve: 'P-384' },
+        verifyAlg: { name: 'ECDSA', hash: 'SHA-384' },
+      };
+    case 'ES512':
+      return {
+        importAlg: { name: 'ECDSA', namedCurve: 'P-521' },
+        verifyAlg: { name: 'ECDSA', hash: 'SHA-512' },
+      };
+    default:
+      throw new JwtError('unsupported-alg', `alg "${alg}" is not supported`);
+  }
+}
+
+/** Opaque handle for a WebCrypto `CryptoKey`. `lib: ES2022` omits `dom`. */
+export type CryptoKeyHandle = unknown;
+
+// WebCrypto is provided by Bun's runtime; we shim the minimal surface we
+// use so the code typechecks without pulling in the `dom` lib.
+interface SubtleCryptoLike {
+  importKey(
+    format: 'jwk',
+    key: unknown,
+    algorithm: unknown,
+    extractable: boolean,
+    keyUsages: readonly string[],
+  ): Promise<CryptoKeyHandle>;
+  verify(
+    algorithm: unknown,
+    key: CryptoKeyHandle,
+    signature: Uint8Array,
+    data: Uint8Array,
+  ): Promise<boolean>;
+}
+
+function subtle(): SubtleCryptoLike {
+  return (crypto as unknown as { subtle: SubtleCryptoLike }).subtle;
+}
+
+/**
+ * Import a JWK into a WebCrypto `CryptoKey` ready for verification.
+ * `alg` is the token header alg — must match the key's capabilities.
+ */
+export async function importJwk(key: JwkKey, alg: string): Promise<CryptoKeyHandle> {
+  if (!SUPPORTED_ALGS.has(alg)) {
+    throw new JwtError('unsupported-alg', `alg "${alg}" is not supported`);
+  }
+  const { importAlg } = algToImport(alg);
+  return subtle().importKey('jwk', key, importAlg, false, ['verify']);
+}
+
+/**
+ * Verify the JWT signature against `cryptoKey`. Caller is responsible for
+ * selecting the right key from the JWKS based on `header.kid`.
+ */
+export async function verifyJwtSignature(
+  decoded: DecodedJwt,
+  cryptoKey: CryptoKeyHandle,
+): Promise<boolean> {
+  const { verifyAlg } = algToImport(decoded.header.alg);
+  // WebCrypto expects ECDSA signatures as raw concatenated R||S bytes,
+  // which is exactly how JWS encodes them — no conversion needed.
+  const signingBytes = new TextEncoder().encode(decoded.signingInput);
+  return subtle().verify(verifyAlg, cryptoKey, decoded.signature, signingBytes);
+}
+
+/**
+ * Returns true when `now` is inside the JWT's validity window, respecting
+ * `clockSkewSec` tolerance on both sides. `exp` and `iat` MUST be present
+ * per this project's policy (RFC 7519 says `exp` is optional, but
+ * enterprise IdPs always issue it and we reject tokens without it).
+ */
+export function checkTimeClaims(
+  claims: JwtClaims,
+  nowSec: number,
+  clockSkewSec: number,
+):
+  | { ok: true }
+  | { ok: false; code: 'expired' | 'not-yet-valid' | 'missing-claim'; field: string } {
+  if (typeof claims.exp !== 'number') return { ok: false, code: 'missing-claim', field: 'exp' };
+  if (typeof claims.iat !== 'number') return { ok: false, code: 'missing-claim', field: 'iat' };
+  if (nowSec > claims.exp + clockSkewSec) {
+    return { ok: false, code: 'expired', field: 'exp' };
+  }
+  // iat in the far future is suspicious — use clock-skew for tolerance.
+  if (claims.iat > nowSec + clockSkewSec) {
+    return { ok: false, code: 'not-yet-valid', field: 'iat' };
+  }
+  if (typeof claims.nbf === 'number' && claims.nbf > nowSec + clockSkewSec) {
+    return { ok: false, code: 'not-yet-valid', field: 'nbf' };
+  }
+  return { ok: true };
+}
+
+export function audienceMatches(claims: JwtClaims, expected: string): boolean {
+  const aud = claims.aud;
+  if (typeof aud === 'string') return aud === expected;
+  if (Array.isArray(aud)) return aud.includes(expected);
+  return false;
+}
+
+export function extractScopes(claims: JwtClaims): string[] {
+  const out: string[] = [];
+  if (typeof claims.scope === 'string' && claims.scope.length > 0) {
+    for (const s of claims.scope.split(/\s+/)) if (s) out.push(s);
+  }
+  const scp = claims.scp;
+  if (typeof scp === 'string' && scp.length > 0) {
+    for (const s of scp.split(/\s+/)) if (s) out.push(s);
+  } else if (Array.isArray(scp)) {
+    for (const s of scp) if (typeof s === 'string' && s.length > 0) out.push(s);
+  }
+  return out;
+}

--- a/packages/plugin-agent-rpc/src/auth/oauth2-client.test.ts
+++ b/packages/plugin-agent-rpc/src/auth/oauth2-client.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, test } from 'bun:test';
+import type { AgentRpcEnvelope } from '@declaragent/core';
+import { type OAuth2ClientPeerConfig, createOAuth2ClientAuthProvider } from './oauth2-client.js';
+import { generateRs256KeyPair, signJwt } from './test-jwt.js';
+
+const TOKEN_ENDPOINT = 'https://idp.example.com/oauth2/token';
+const JWKS_URI = 'https://idp.example.com/keys';
+const ISSUER = 'https://idp.example.com';
+const AUDIENCE = 'declaragent-peer-b';
+
+function baseConfig(overrides: Partial<OAuth2ClientPeerConfig> = {}): OAuth2ClientPeerConfig {
+  return {
+    provider: 'oauth2-client',
+    tokenEndpoint: TOKEN_ENDPOINT,
+    clientId: 'decl-agent-a',
+    clientSecretRef: 'secret://platform/decl-agent-a-client-secret',
+    jwksUri: JWKS_URI,
+    issuer: ISSUER,
+    audience: AUDIENCE,
+    ...overrides,
+  };
+}
+
+function envelopeWith(token: string): AgentRpcEnvelope {
+  return {
+    version: 1,
+    kind: 'request',
+    messageId: 'm1',
+    correlationId: 'c1',
+    from: 'agent://peer-a',
+    to: 'agent://peer-b',
+    capability: 'cap',
+    replyTo: 'memory://agents.peer-a.responses',
+    payload: {},
+    auth: { kind: 'oauth2-client', token },
+  };
+}
+
+describe('createOAuth2ClientAuthProvider — sign()', () => {
+  test('fetches token lazily + caches across sign calls', async () => {
+    let tokenCalls = 0;
+    const fetch = (async (url: unknown, init?: unknown) => {
+      if (String(url) === TOKEN_ENDPOINT) {
+        tokenCalls += 1;
+        const body = ((init ?? {}) as { body?: string }).body ?? '';
+        expect(body).toContain('grant_type=client_credentials');
+        expect(body).toContain('client_id=decl-agent-a');
+        expect(body).toContain('client_secret=raw-secret');
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ access_token: `tok-${tokenCalls}`, expires_in: 3600 }),
+          text: async () => '',
+        } as unknown as Response;
+      }
+      throw new Error(`unexpected url ${String(url)}`);
+    }) as unknown as typeof globalThis.fetch;
+    const provider = createOAuth2ClientAuthProvider({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: 'decl-agent-a',
+      clientSecret: 'raw-secret',
+      fetch,
+    });
+    const a = await provider.sign({} as AgentRpcEnvelope);
+    const b = await provider.sign({} as AgentRpcEnvelope);
+    expect(a).toEqual({ kind: 'oauth2-client', token: 'tok-1' });
+    expect(b).toEqual({ kind: 'oauth2-client', token: 'tok-1' });
+    expect(tokenCalls).toBe(1);
+  });
+
+  test('refreshes when token nears expiry', async () => {
+    let tokenCalls = 0;
+    let nowMs = 1_000_000;
+    const fetch = (async () => {
+      tokenCalls += 1;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ access_token: `tok-${tokenCalls}`, expires_in: 60 }),
+        text: async () => '',
+      } as unknown as Response;
+    }) as unknown as typeof globalThis.fetch;
+    const provider = createOAuth2ClientAuthProvider({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: 'decl-agent-a',
+      clientSecret: 's',
+      refreshSkewSec: 30,
+      fetch,
+      now: () => nowMs,
+    });
+    await provider.sign({} as AgentRpcEnvelope);
+    nowMs += 35_000; // within the refresh-skew window
+    await provider.sign({} as AgentRpcEnvelope);
+    expect(tokenCalls).toBe(2);
+  });
+
+  test('token endpoint down → JwtError propagates from sign', async () => {
+    const fetch = (async () => {
+      throw new Error('ECONNREFUSED');
+    }) as unknown as typeof globalThis.fetch;
+    const provider = createOAuth2ClientAuthProvider({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: 'c',
+      clientSecret: 's',
+      fetch,
+    });
+    await expect(provider.sign({} as AgentRpcEnvelope)).rejects.toThrow(/token endpoint/);
+  });
+});
+
+describe('createOAuth2ClientAuthProvider — verify()', () => {
+  test('accepts a valid token', async () => {
+    const pair = await generateRs256KeyPair('k-1');
+    const token = await signJwt({
+      pair,
+      claims: {
+        iss: ISSUER,
+        aud: AUDIENCE,
+        sub: 'client-decl-agent-a',
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 300,
+        scope: 'rpc:invoke',
+      },
+    });
+    const fetch = (async (url: unknown) => {
+      if (String(url) === JWKS_URI) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ keys: [pair.publicJwk] }),
+          text: async () => '',
+        } as unknown as Response;
+      }
+      throw new Error(`unexpected ${String(url)}`);
+    }) as unknown as typeof globalThis.fetch;
+    const provider = createOAuth2ClientAuthProvider({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: 'c',
+      clientSecret: 's',
+      fetch,
+    });
+    const result = await provider.verify(
+      envelopeWith(token),
+      baseConfig({ scopes: ['rpc:invoke'] }),
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  test('rejects alg:none', async () => {
+    const pair = await generateRs256KeyPair('k-1');
+    const token = await signJwt({
+      pair,
+      alg: 'none',
+      emptySig: true,
+      claims: {
+        iss: ISSUER,
+        aud: AUDIENCE,
+        sub: 'c',
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 300,
+      },
+    });
+    const fetch = (async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ keys: [pair.publicJwk] }),
+      text: async () => '',
+    })) as unknown as typeof globalThis.fetch;
+    const provider = createOAuth2ClientAuthProvider({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: 'c',
+      clientSecret: 's',
+      fetch,
+    });
+    const result = await provider.verify(envelopeWith(token), baseConfig());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('alg-none');
+  });
+
+  test('rejects missing iat', async () => {
+    const pair = await generateRs256KeyPair('k-1');
+    const token = await signJwt({
+      pair,
+      claims: {
+        iss: ISSUER,
+        aud: AUDIENCE,
+        sub: 'c',
+        exp: Math.floor(Date.now() / 1000) + 300,
+      },
+    });
+    const fetch = (async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ keys: [pair.publicJwk] }),
+      text: async () => '',
+    })) as unknown as typeof globalThis.fetch;
+    const provider = createOAuth2ClientAuthProvider({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: 'c',
+      clientSecret: 's',
+      fetch,
+    });
+    const result = await provider.verify(envelopeWith(token), baseConfig());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('missing-claim');
+  });
+
+  test('rejects missing required scope', async () => {
+    const pair = await generateRs256KeyPair('k-1');
+    const token = await signJwt({
+      pair,
+      claims: {
+        iss: ISSUER,
+        aud: AUDIENCE,
+        sub: 'c',
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 300,
+        scope: 'other:scope',
+      },
+    });
+    const fetch = (async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ keys: [pair.publicJwk] }),
+      text: async () => '',
+    })) as unknown as typeof globalThis.fetch;
+    const provider = createOAuth2ClientAuthProvider({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: 'c',
+      clientSecret: 's',
+      fetch,
+    });
+    const result = await provider.verify(
+      envelopeWith(token),
+      baseConfig({ scopes: ['rpc:invoke'] }),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('insufficient-scope');
+  });
+
+  test('JWKS unreachable → idp-unreachable', async () => {
+    const pair = await generateRs256KeyPair('k-1');
+    const token = await signJwt({
+      pair,
+      claims: {
+        iss: ISSUER,
+        aud: AUDIENCE,
+        sub: 'c',
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 300,
+      },
+    });
+    const fetch = (async () => {
+      throw new Error('network down');
+    }) as unknown as typeof globalThis.fetch;
+    const provider = createOAuth2ClientAuthProvider({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: 'c',
+      clientSecret: 's',
+      fetch,
+    });
+    const result = await provider.verify(envelopeWith(token), baseConfig());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('idp-unreachable');
+  });
+
+  test('config-error when jwksUri is not configured', async () => {
+    const provider = createOAuth2ClientAuthProvider({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: 'c',
+      clientSecret: 's',
+      fetch: (async () => ({}) as unknown as Response) as unknown as typeof globalThis.fetch,
+    });
+    const { jwksUri: _jwksUri, ...partial } = baseConfig();
+    void _jwksUri;
+    const cfg = partial as OAuth2ClientPeerConfig;
+    const result = await provider.verify(envelopeWith('a.b.c'), cfg);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('config-error');
+  });
+});

--- a/packages/plugin-agent-rpc/src/auth/oauth2-client.ts
+++ b/packages/plugin-agent-rpc/src/auth/oauth2-client.ts
@@ -1,0 +1,372 @@
+/**
+ * OAuth2 Client-Credentials {@link RpcAuthProvider}.
+ *
+ * Fetches a bearer access token via `grant_type=client_credentials` against
+ * a configured token endpoint. Signs outbound envelopes with the cached
+ * token and refreshes ~30s before `expires_in` expires.
+ *
+ * Verification shares JWT-over-JWKS semantics with {@link createOidcAuthProvider}
+ * — Client-Credentials tokens issued by every modern IdP are JWTs with
+ * the same claim set. Configuring the peer with an `oauth2-client` block
+ * rather than `oidc` carries one operator-facing difference: the provider
+ * knows how to mint its own token, so no external token loader is needed.
+ *
+ * Token caching: refreshed at `expires_at - refreshSkewSec`. A concurrent
+ * `sign()` during refresh awaits the in-flight fetch instead of issuing a
+ * second request.
+ *
+ * @since 1.2.0
+ */
+
+import type { AgentRpcEnvelope, RpcAuth } from '@declaragent/core';
+import {
+  type DecodedJwt,
+  type JwkKey,
+  JwtError,
+  SUPPORTED_ALGS,
+  audienceMatches,
+  checkTimeClaims,
+  decodeJwt,
+  extractScopes,
+  importJwk,
+  verifyJwtSignature,
+} from './jwt.js';
+import type {
+  RpcAuthPeerConfigBase,
+  RpcAuthPrincipal,
+  RpcAuthProvider,
+  RpcAuthVerifyResult,
+} from './types.js';
+
+export interface OAuth2ClientPeerConfig extends RpcAuthPeerConfigBase {
+  readonly provider: 'oauth2-client';
+  readonly tokenEndpoint: string;
+  readonly clientId: string;
+  /** `secret://` reference consumed by an external resolver — raw value at verify time isn't needed receiver-side. */
+  readonly clientSecretRef?: string;
+  /** JWKS URI used for receive-path JWT verification. */
+  readonly jwksUri?: string;
+  /** Expected issuer claim. */
+  readonly issuer?: string;
+  /** Expected audience claim. */
+  readonly audience?: string;
+  readonly scopes?: readonly string[];
+}
+
+export interface CreateOAuth2ClientAuthProviderOptions {
+  /** Token endpoint the provider posts to. */
+  readonly tokenEndpoint: string;
+  readonly clientId: string;
+  /** Resolved secret value — the config loader passes the already-resolved value. */
+  readonly clientSecret: string;
+  /** Space-separated or array scopes included in the token request. */
+  readonly scopes?: readonly string[];
+  /** Audience to request — some IdPs require it (Auth0). */
+  readonly audience?: string;
+  /** Refresh this many seconds before expiry. Defaults to 30. */
+  readonly refreshSkewSec?: number;
+  /** Clock-skew window for receive-path JWT verification. Defaults to 60s. */
+  readonly clockSkewSec?: number;
+  /** Injected clock. */
+  readonly now?: () => number;
+  /** Injected fetch. */
+  readonly fetch?: typeof globalThis.fetch;
+  /** Receive-path only: expected issuer for verify(). */
+  readonly expectedIssuer?: string;
+  /** Receive-path only: expected audience for verify(). */
+  readonly expectedAudience?: string;
+  /** Receive-path only: JWKS URI. */
+  readonly jwksUri?: string;
+  /** Receive-path JWKS cache TTL. Defaults to 5m. */
+  readonly jwksCacheTtlMs?: number;
+}
+
+interface CachedToken {
+  readonly token: string;
+  readonly expiresAtMs: number;
+}
+
+interface JwksCacheEntry {
+  readonly fetchedAt: number;
+  readonly keys: readonly JwkKey[];
+}
+
+const DEFAULT_REFRESH_SKEW_SEC = 30;
+const DEFAULT_CLOCK_SKEW_SEC = 60;
+const DEFAULT_JWKS_TTL_MS = 5 * 60 * 1000;
+
+export function createOAuth2ClientAuthProvider(
+  options: CreateOAuth2ClientAuthProviderOptions,
+): RpcAuthProvider<OAuth2ClientPeerConfig> {
+  const now = options.now ?? Date.now;
+  const fetchImpl = options.fetch ?? globalThis.fetch;
+  const refreshSkewMs = (options.refreshSkewSec ?? DEFAULT_REFRESH_SKEW_SEC) * 1000;
+  const clockSkewSec = options.clockSkewSec ?? DEFAULT_CLOCK_SKEW_SEC;
+  const jwksTtlMs = options.jwksCacheTtlMs ?? DEFAULT_JWKS_TTL_MS;
+
+  let cached: CachedToken | undefined;
+  let inflight: Promise<CachedToken> | undefined;
+  const jwksCache = new Map<string, JwksCacheEntry>();
+
+  async function fetchToken(): Promise<CachedToken> {
+    const body = new URLSearchParams();
+    body.set('grant_type', 'client_credentials');
+    body.set('client_id', options.clientId);
+    body.set('client_secret', options.clientSecret);
+    if (options.scopes && options.scopes.length > 0) {
+      body.set('scope', options.scopes.join(' '));
+    }
+    if (options.audience) {
+      body.set('audience', options.audience);
+    }
+    let res: Response;
+    try {
+      res = await fetchImpl(options.tokenEndpoint, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+          accept: 'application/json',
+        },
+        body: body.toString(),
+      });
+    } catch (err) {
+      throw new JwtError(
+        'idp-unreachable',
+        `token endpoint fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new JwtError(
+        'idp-unreachable',
+        `token endpoint returned HTTP ${res.status}: ${text.slice(0, 200)}`,
+      );
+    }
+    const doc = (await res.json()) as {
+      access_token?: string;
+      expires_in?: number;
+      token_type?: string;
+    };
+    if (!doc || typeof doc.access_token !== 'string') {
+      throw new JwtError('malformed-token', 'token endpoint response missing access_token');
+    }
+    const expiresInSec = typeof doc.expires_in === 'number' ? doc.expires_in : 300;
+    const expiresAtMs = now() + expiresInSec * 1000;
+    return { token: doc.access_token, expiresAtMs };
+  }
+
+  async function currentToken(): Promise<CachedToken> {
+    if (cached && cached.expiresAtMs - now() > refreshSkewMs) {
+      return cached;
+    }
+    if (inflight) return inflight;
+    inflight = (async () => {
+      try {
+        const next = await fetchToken();
+        cached = next;
+        return next;
+      } finally {
+        inflight = undefined;
+      }
+    })();
+    return inflight;
+  }
+
+  async function fetchJwks(uri: string): Promise<readonly JwkKey[]> {
+    const entry = jwksCache.get(uri);
+    if (entry && now() - entry.fetchedAt < jwksTtlMs) return entry.keys;
+    try {
+      const res = await fetchImpl(uri);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const doc = (await res.json()) as { keys?: JwkKey[] };
+      const keys = Array.isArray(doc?.keys) ? doc.keys : [];
+      jwksCache.set(uri, { fetchedAt: now(), keys });
+      return keys;
+    } catch (err) {
+      throw new JwtError(
+        'idp-unreachable',
+        `JWKS fetch failed for ${uri}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  function selectKey(keys: readonly JwkKey[], decoded: DecodedJwt): JwkKey | undefined {
+    const kid = decoded.header.kid;
+    if (typeof kid === 'string' && kid.length > 0) {
+      return keys.find((k) => k.kid === kid);
+    }
+    return keys.length === 1 ? keys[0] : undefined;
+  }
+
+  return {
+    name: 'oauth2-client',
+    async sign(_envelope: AgentRpcEnvelope): Promise<RpcAuth> {
+      const tok = await currentToken();
+      const auth: RpcAuth =
+        options.scopes && options.scopes.length > 0
+          ? { kind: 'oauth2-client', token: tok.token, scope: options.scopes.join(' ') }
+          : { kind: 'oauth2-client', token: tok.token };
+      return auth;
+    },
+    async verify(
+      envelope: AgentRpcEnvelope,
+      peerConfig: OAuth2ClientPeerConfig,
+    ): Promise<RpcAuthVerifyResult> {
+      const auth = envelope.auth;
+      if (!auth) {
+        return { ok: false, reason: 'missing-auth', message: 'envelope missing auth block' };
+      }
+      if (auth.kind !== 'oauth2-client') {
+        return {
+          ok: false,
+          reason: 'wrong-kind',
+          message: `expected auth.kind "oauth2-client", got "${auth.kind}"`,
+        };
+      }
+      const jwksUri = peerConfig.jwksUri ?? options.jwksUri;
+      if (!jwksUri) {
+        return {
+          ok: false,
+          reason: 'config-error',
+          message: 'oauth2-client verify requires jwksUri on peerConfig or provider options',
+        };
+      }
+      const expectedIssuer = peerConfig.issuer ?? options.expectedIssuer;
+      const expectedAudience = peerConfig.audience ?? options.expectedAudience;
+      if (!expectedIssuer || !expectedAudience) {
+        return {
+          ok: false,
+          reason: 'config-error',
+          message:
+            'oauth2-client verify requires issuer + audience on peerConfig or provider options',
+        };
+      }
+
+      let decoded: DecodedJwt;
+      try {
+        decoded = decodeJwt(auth.token);
+      } catch (err) {
+        return {
+          ok: false,
+          reason: 'malformed-token',
+          message: err instanceof Error ? err.message : String(err),
+        };
+      }
+      if (decoded.header.alg === 'none' || decoded.header.alg === 'None') {
+        return { ok: false, reason: 'alg-none', message: 'alg: none is not accepted' };
+      }
+      if (!SUPPORTED_ALGS.has(decoded.header.alg)) {
+        return {
+          ok: false,
+          reason: 'malformed-token',
+          message: `unsupported alg "${decoded.header.alg}"`,
+        };
+      }
+
+      if (typeof decoded.claims.iss !== 'string') {
+        return { ok: false, reason: 'missing-claim', message: 'claim `iss` is required' };
+      }
+      if (decoded.claims.aud === undefined) {
+        return { ok: false, reason: 'missing-claim', message: 'claim `aud` is required' };
+      }
+      if (decoded.claims.iss !== expectedIssuer) {
+        return {
+          ok: false,
+          reason: 'wrong-issuer',
+          message: `issuer "${decoded.claims.iss}" does not match expected "${expectedIssuer}"`,
+        };
+      }
+      if (!audienceMatches(decoded.claims, expectedAudience)) {
+        return {
+          ok: false,
+          reason: 'wrong-audience',
+          message: `audience does not include "${expectedAudience}"`,
+        };
+      }
+
+      let keys: readonly JwkKey[];
+      try {
+        keys = await fetchJwks(jwksUri);
+      } catch (err) {
+        return {
+          ok: false,
+          reason: 'idp-unreachable',
+          message: err instanceof Error ? err.message : String(err),
+        };
+      }
+      let key = selectKey(keys, decoded);
+      if (!key) {
+        jwksCache.delete(jwksUri);
+        try {
+          keys = await fetchJwks(jwksUri);
+        } catch (err) {
+          return {
+            ok: false,
+            reason: 'idp-unreachable',
+            message: err instanceof Error ? err.message : String(err),
+          };
+        }
+        key = selectKey(keys, decoded);
+      }
+      if (!key) {
+        return {
+          ok: false,
+          reason: 'bad-signature',
+          message: `no JWKS key matches kid "${decoded.header.kid ?? '<none>'}"`,
+        };
+      }
+
+      let sigOk = false;
+      try {
+        const cryptoKey = await importJwk(key, decoded.header.alg);
+        sigOk = await verifyJwtSignature(decoded, cryptoKey);
+      } catch (err) {
+        return {
+          ok: false,
+          reason: 'bad-signature',
+          message: `signature verify threw: ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+      if (!sigOk) {
+        return { ok: false, reason: 'bad-signature', message: 'JWT signature did not verify' };
+      }
+
+      const timeCheck = checkTimeClaims(decoded.claims, Math.floor(now() / 1000), clockSkewSec);
+      if (!timeCheck.ok) {
+        const reason =
+          timeCheck.code === 'expired'
+            ? 'expired'
+            : timeCheck.code === 'not-yet-valid'
+              ? 'not-yet-valid'
+              : 'missing-claim';
+        return {
+          ok: false,
+          reason,
+          message: `time-claim check failed: ${timeCheck.code} on ${timeCheck.field}`,
+        };
+      }
+
+      const scopes = extractScopes(decoded.claims);
+      const required = peerConfig.scopes ?? [];
+      for (const s of required) {
+        if (!scopes.includes(s)) {
+          return {
+            ok: false,
+            reason: 'insufficient-scope',
+            message: `missing required scope "${s}"`,
+          };
+        }
+      }
+
+      const sub = typeof decoded.claims.sub === 'string' ? decoded.claims.sub : options.clientId;
+      const principal: RpcAuthPrincipal = {
+        subject: sub,
+        issuer: decoded.claims.iss as string,
+        audience: decoded.claims.aud as string | readonly string[],
+        scopes,
+        claims: decoded.claims as Readonly<Record<string, unknown>>,
+      };
+      return { ok: true, principal };
+    },
+  };
+}

--- a/packages/plugin-agent-rpc/src/auth/oidc.test.ts
+++ b/packages/plugin-agent-rpc/src/auth/oidc.test.ts
@@ -1,0 +1,377 @@
+import { describe, expect, test } from 'bun:test';
+import type { AgentRpcEnvelope } from '@declaragent/core';
+import { type OidcPeerConfig, createOidcAuthProvider } from './oidc.js';
+import { cannedFetch, generateRs256KeyPair, signJwt } from './test-jwt.js';
+
+const ISSUER = 'https://dex.example.com';
+const AUDIENCE = 'declaragent-peer-a';
+const JWKS_URI = `${ISSUER}/keys`;
+
+function envelopeWith(token: string): AgentRpcEnvelope {
+  return {
+    version: 1,
+    kind: 'request',
+    messageId: 'm1',
+    correlationId: 'c1',
+    from: 'agent://peer-a',
+    to: 'agent://peer-b',
+    capability: 'cap',
+    replyTo: 'memory://agents.peer-a.responses',
+    payload: {},
+    auth: { kind: 'oidc', token },
+  };
+}
+
+function baseConfig(overrides: Partial<OidcPeerConfig> = {}): OidcPeerConfig {
+  return {
+    provider: 'oidc',
+    issuer: ISSUER,
+    audience: AUDIENCE,
+    jwksUri: JWKS_URI,
+    ...overrides,
+  };
+}
+
+async function mintToken(
+  pair: Awaited<ReturnType<typeof generateRs256KeyPair>>,
+  claims: Record<string, unknown>,
+  opts: { omitKid?: boolean; alg?: string; emptySig?: boolean } = {},
+): Promise<string> {
+  const sigOpt: { omitKid?: boolean; alg?: string; emptySig?: boolean } = {};
+  if (opts.omitKid !== undefined) sigOpt.omitKid = opts.omitKid;
+  if (opts.alg !== undefined) sigOpt.alg = opts.alg;
+  if (opts.emptySig !== undefined) sigOpt.emptySig = opts.emptySig;
+  return signJwt({
+    pair,
+    ...sigOpt,
+    claims: {
+      iss: ISSUER,
+      aud: AUDIENCE,
+      sub: 'peer-a',
+      iat: Math.floor(Date.now() / 1000),
+      exp: Math.floor(Date.now() / 1000) + 300,
+      ...claims,
+    },
+  });
+}
+
+describe('createOidcAuthProvider — sign()', () => {
+  test('stamps an oidc auth block with the configured token', async () => {
+    const provider = createOidcAuthProvider({ token: 'tok-abc', fetch: cannedFetch({}) });
+    const env = envelopeWith('ignored');
+    const auth = await provider.sign(env);
+    expect(auth).toEqual({ kind: 'oidc', token: 'tok-abc' });
+  });
+
+  test('includes keyId hint when provided', async () => {
+    const provider = createOidcAuthProvider({
+      token: 'tok',
+      keyId: 'kid-7',
+      fetch: cannedFetch({}),
+    });
+    const auth = await provider.sign(envelopeWith('x'));
+    expect(auth).toEqual({ kind: 'oidc', token: 'tok', keyId: 'kid-7' });
+  });
+});
+
+describe('createOidcAuthProvider — verify()', () => {
+  test('accepts a valid token', async () => {
+    const pair = await generateRs256KeyPair('k1');
+    const token = await mintToken(pair, {});
+    const provider = createOidcAuthProvider({
+      token,
+      fetch: cannedFetch({ [JWKS_URI]: { body: { keys: [pair.publicJwk] } } }),
+    });
+    const result = await provider.verify(envelopeWith(token), baseConfig());
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.principal.subject).toBe('peer-a');
+      expect(result.principal.issuer).toBe(ISSUER);
+    }
+  });
+
+  test('rejects alg:none', async () => {
+    const pair = await generateRs256KeyPair('k1');
+    const token = await mintToken(pair, {}, { alg: 'none', emptySig: true });
+    const provider = createOidcAuthProvider({
+      token,
+      fetch: cannedFetch({ [JWKS_URI]: { body: { keys: [pair.publicJwk] } } }),
+    });
+    const result = await provider.verify(envelopeWith(token), baseConfig());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('alg-none');
+  });
+
+  test('rejects missing exp claim', async () => {
+    const pair = await generateRs256KeyPair('k1');
+    const token = await signJwt({
+      pair,
+      claims: {
+        iss: ISSUER,
+        aud: AUDIENCE,
+        sub: 'peer-a',
+        iat: Math.floor(Date.now() / 1000),
+      },
+    });
+    const provider = createOidcAuthProvider({
+      token,
+      fetch: cannedFetch({ [JWKS_URI]: { body: { keys: [pair.publicJwk] } } }),
+    });
+    const result = await provider.verify(envelopeWith(token), baseConfig());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('missing-claim');
+  });
+
+  test('rejects expired token beyond the clock-skew window', async () => {
+    const pair = await generateRs256KeyPair('k1');
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt({
+      pair,
+      claims: {
+        iss: ISSUER,
+        aud: AUDIENCE,
+        sub: 'peer-a',
+        iat: now - 1000,
+        exp: now - 120, // 120s in the past; 60s skew → still expired
+      },
+    });
+    const provider = createOidcAuthProvider({
+      token,
+      clockSkewSec: 60,
+      fetch: cannedFetch({ [JWKS_URI]: { body: { keys: [pair.publicJwk] } } }),
+    });
+    const result = await provider.verify(envelopeWith(token), baseConfig());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('expired');
+  });
+
+  test('accepts a token expired within clock-skew window', async () => {
+    const pair = await generateRs256KeyPair('k1');
+    const now = Math.floor(Date.now() / 1000);
+    const token = await signJwt({
+      pair,
+      claims: {
+        iss: ISSUER,
+        aud: AUDIENCE,
+        sub: 'peer-a',
+        iat: now - 600,
+        exp: now - 30, // 30s past but skew is 60s
+      },
+    });
+    const provider = createOidcAuthProvider({
+      token,
+      clockSkewSec: 60,
+      fetch: cannedFetch({ [JWKS_URI]: { body: { keys: [pair.publicJwk] } } }),
+    });
+    const result = await provider.verify(envelopeWith(token), baseConfig());
+    expect(result.ok).toBe(true);
+  });
+
+  test('rejects wrong audience', async () => {
+    const pair = await generateRs256KeyPair('k1');
+    const token = await signJwt({
+      pair,
+      claims: {
+        iss: ISSUER,
+        aud: 'someone-else',
+        sub: 'peer-a',
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 300,
+      },
+    });
+    const provider = createOidcAuthProvider({
+      token,
+      fetch: cannedFetch({ [JWKS_URI]: { body: { keys: [pair.publicJwk] } } }),
+    });
+    const result = await provider.verify(envelopeWith(token), baseConfig());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('wrong-audience');
+  });
+
+  test('accepts aud array containing the expected audience', async () => {
+    const pair = await generateRs256KeyPair('k1');
+    const token = await signJwt({
+      pair,
+      claims: {
+        iss: ISSUER,
+        aud: ['other', AUDIENCE],
+        sub: 'peer-a',
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 300,
+      },
+    });
+    const provider = createOidcAuthProvider({
+      token,
+      fetch: cannedFetch({ [JWKS_URI]: { body: { keys: [pair.publicJwk] } } }),
+    });
+    const result = await provider.verify(envelopeWith(token), baseConfig());
+    expect(result.ok).toBe(true);
+  });
+
+  test('rejects wrong issuer', async () => {
+    const pair = await generateRs256KeyPair('k1');
+    const token = await signJwt({
+      pair,
+      claims: {
+        iss: 'https://evil.example.com',
+        aud: AUDIENCE,
+        sub: 'peer-a',
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 300,
+      },
+    });
+    const provider = createOidcAuthProvider({
+      token,
+      fetch: cannedFetch({ [JWKS_URI]: { body: { keys: [pair.publicJwk] } } }),
+    });
+    const result = await provider.verify(envelopeWith(token), baseConfig());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('wrong-issuer');
+  });
+
+  test('strict scope check: missing required scope rejects', async () => {
+    const pair = await generateRs256KeyPair('k1');
+    const token = await mintToken(pair, { scope: 'rpc:read' });
+    const provider = createOidcAuthProvider({
+      token,
+      fetch: cannedFetch({ [JWKS_URI]: { body: { keys: [pair.publicJwk] } } }),
+    });
+    const result = await provider.verify(
+      envelopeWith(token),
+      baseConfig({ scopes: ['rpc:read', 'rpc:invoke'] }),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('insufficient-scope');
+  });
+
+  test('strict scope check: all required scopes present accepts', async () => {
+    const pair = await generateRs256KeyPair('k1');
+    const token = await mintToken(pair, { scope: 'rpc:read rpc:invoke rpc:admin' });
+    const provider = createOidcAuthProvider({
+      token,
+      fetch: cannedFetch({ [JWKS_URI]: { body: { keys: [pair.publicJwk] } } }),
+    });
+    const result = await provider.verify(
+      envelopeWith(token),
+      baseConfig({ scopes: ['rpc:read', 'rpc:invoke'] }),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.principal.scopes).toContain('rpc:invoke');
+    }
+  });
+
+  test('IdP unreachable (JWKS fetch fails) → idp-unreachable', async () => {
+    const pair = await generateRs256KeyPair('k1');
+    const token = await mintToken(pair, {});
+    const failFetch = (async () => {
+      throw new Error('ECONNREFUSED');
+    }) as unknown as typeof globalThis.fetch;
+    const provider = createOidcAuthProvider({ token, fetch: failFetch });
+    const result = await provider.verify(envelopeWith(token), baseConfig());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('idp-unreachable');
+  });
+
+  test('JWKS cache reuses keys within TTL', async () => {
+    const pair = await generateRs256KeyPair('k1');
+    const token = await mintToken(pair, {});
+    let fetches = 0;
+    const trackingFetch = (async (url: unknown) => {
+      fetches += 1;
+      const u = String(url);
+      if (u === JWKS_URI) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ keys: [pair.publicJwk] }),
+          text: async () => '',
+        } as unknown as Response;
+      }
+      throw new Error(`unexpected url ${u}`);
+    }) as unknown as typeof globalThis.fetch;
+    const provider = createOidcAuthProvider({
+      token,
+      jwksCacheTtlMs: 10_000,
+      fetch: trackingFetch,
+    });
+    for (let i = 0; i < 3; i += 1) {
+      const r = await provider.verify(envelopeWith(token), baseConfig());
+      expect(r.ok).toBe(true);
+    }
+    expect(fetches).toBe(1);
+  });
+
+  test('JWKS refresh after TTL expiry', async () => {
+    const pair = await generateRs256KeyPair('k1');
+    const token = await mintToken(pair, {});
+    let fetches = 0;
+    let nowMs = 1_000_000;
+    const trackingFetch = (async () => {
+      fetches += 1;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ keys: [pair.publicJwk] }),
+        text: async () => '',
+      } as unknown as Response;
+    }) as unknown as typeof globalThis.fetch;
+    const provider = createOidcAuthProvider({
+      token,
+      jwksCacheTtlMs: 1000,
+      fetch: trackingFetch,
+      now: () => nowMs,
+    });
+    await provider.verify(envelopeWith(token), baseConfig());
+    nowMs += 2000; // past TTL
+    await provider.verify(envelopeWith(token), baseConfig());
+    expect(fetches).toBe(2);
+  });
+
+  test('discovers jwks_uri when peerConfig omits it', async () => {
+    const pair = await generateRs256KeyPair('k1');
+    const token = await mintToken(pair, {});
+    const discoveredUri = `${ISSUER}/alt-jwks`;
+    const provider = createOidcAuthProvider({
+      token,
+      fetch: cannedFetch({
+        [`${ISSUER}/.well-known/openid-configuration`]: {
+          body: { issuer: ISSUER, jwks_uri: discoveredUri },
+        },
+        [discoveredUri]: { body: { keys: [pair.publicJwk] } },
+      }),
+    });
+    const cfg: OidcPeerConfig = { provider: 'oidc', issuer: ISSUER, audience: AUDIENCE };
+    const result = await provider.verify(envelopeWith(token), cfg);
+    expect(result.ok).toBe(true);
+  });
+
+  test('missing auth block rejects with missing-auth', async () => {
+    const provider = createOidcAuthProvider({ token: 'x', fetch: cannedFetch({}) });
+    const { auth: _auth, ...rest } = envelopeWith('x');
+    void _auth;
+    const env = rest as AgentRpcEnvelope;
+    const result = await provider.verify(env, baseConfig());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('missing-auth');
+  });
+
+  test('wrong auth kind rejects with wrong-kind', async () => {
+    const provider = createOidcAuthProvider({ token: 'x', fetch: cannedFetch({}) });
+    const env = envelopeWith('x');
+    env.auth = { kind: 'internal' };
+    const result = await provider.verify(env, baseConfig());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('wrong-kind');
+  });
+
+  test('malformed token rejects', async () => {
+    const provider = createOidcAuthProvider({ token: 'x', fetch: cannedFetch({}) });
+    const result = await provider.verify(envelopeWith('not.a.jwt'), baseConfig());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      // accept malformed-token OR wrong-issuer depending on what Base64 decode yields
+      expect(['malformed-token']).toContain(result.reason);
+    }
+  });
+});

--- a/packages/plugin-agent-rpc/src/auth/oidc.ts
+++ b/packages/plugin-agent-rpc/src/auth/oidc.ts
@@ -1,0 +1,317 @@
+/**
+ * OIDC {@link RpcAuthProvider}.
+ *
+ * On `sign()`, stamps the envelope with an `{ kind: 'oidc', token, keyId? }`
+ * block. The token is supplied by the caller — typically a short-lived
+ * projected Kubernetes token, a workload-identity-minted JWT, or an
+ * operator-provided bearer. This provider deliberately does NOT perform
+ * token acquisition; OAuth2 Client-Credentials has its own flow in
+ * `./oauth2-client.ts`.
+ *
+ * On `verify()`, validates the token against a cached JWKS:
+ *
+ *   1. Decode, reject `alg: none` or any alg outside {@link SUPPORTED_ALGS}.
+ *   2. Select the key by `kid` (falls back to the first key when the JWT
+ *      header omits `kid` AND the JWKS has exactly one key).
+ *   3. WebCrypto signature verify.
+ *   4. Issuer claim equals the configured `issuer`.
+ *   5. Audience claim contains the configured `audience`.
+ *   6. `exp` / `iat` present, within 60s clock-skew.
+ *   7. Strict scope check — every scope in `peerConfig.scopes` must be
+ *      present in the token's `scope` / `scp` claim.
+ *
+ * JWKS is fetched on demand with a 5-minute TTL. Fetch failure after the
+ * cache has expired is fail-closed (`idp-unreachable`). A fresh cache is
+ * reused without retry during the TTL window so a transient IdP blip
+ * doesn't take inter-agent traffic down.
+ *
+ * @since 1.2.0
+ */
+
+import type { AgentRpcEnvelope, RpcAuth } from '@declaragent/core';
+import {
+  type DecodedJwt,
+  type JwkKey,
+  JwtError,
+  SUPPORTED_ALGS,
+  audienceMatches,
+  checkTimeClaims,
+  decodeJwt,
+  extractScopes,
+  importJwk,
+  verifyJwtSignature,
+} from './jwt.js';
+import type {
+  RpcAuthPeerConfigBase,
+  RpcAuthPrincipal,
+  RpcAuthProvider,
+  RpcAuthVerifyResult,
+} from './types.js';
+
+export interface OidcPeerConfig extends RpcAuthPeerConfigBase {
+  readonly provider: 'oidc';
+  readonly issuer: string;
+  readonly audience: string;
+  /** Override JWKS URI. When absent we derive via `/.well-known/openid-configuration`. */
+  readonly jwksUri?: string;
+  /** Scopes required on incoming tokens. Strict AND semantics. */
+  readonly scopes?: readonly string[];
+}
+
+export interface CreateOidcAuthProviderOptions {
+  /** Bearer token to stamp on outbound envelopes. */
+  readonly token: string;
+  /** Optional `kid` hint for the receiver when the token header lacks it. */
+  readonly keyId?: string;
+  /** JWKS cache TTL. Defaults to 5 minutes. */
+  readonly jwksCacheTtlMs?: number;
+  /** Clock-skew tolerance in seconds. Defaults to 60. */
+  readonly clockSkewSec?: number;
+  /** Injected clock (ms-epoch). */
+  readonly now?: () => number;
+  /** Injected fetch — tests override to simulate IdP behavior. */
+  readonly fetch?: typeof globalThis.fetch;
+}
+
+interface JwksCacheEntry {
+  readonly fetchedAt: number;
+  readonly keys: readonly JwkKey[];
+}
+
+const DEFAULT_JWKS_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_CLOCK_SKEW_SEC = 60;
+
+export function createOidcAuthProvider(
+  options: CreateOidcAuthProviderOptions,
+): RpcAuthProvider<OidcPeerConfig> {
+  const jwksCache = new Map<string, JwksCacheEntry>();
+  const discoveryCache = new Map<string, string>();
+  const ttlMs = options.jwksCacheTtlMs ?? DEFAULT_JWKS_TTL_MS;
+  const clockSkewSec = options.clockSkewSec ?? DEFAULT_CLOCK_SKEW_SEC;
+  const now = options.now ?? Date.now;
+  const fetchImpl = options.fetch ?? globalThis.fetch;
+
+  async function discoverJwksUri(issuer: string): Promise<string> {
+    const cached = discoveryCache.get(issuer);
+    if (cached) return cached;
+    const url = `${issuer.replace(/\/$/, '')}/.well-known/openid-configuration`;
+    const res = await fetchImpl(url);
+    if (!res.ok) {
+      throw new JwtError('idp-unreachable', `OIDC discovery ${url} returned HTTP ${res.status}`);
+    }
+    const doc = (await res.json()) as { jwks_uri?: string; issuer?: string };
+    if (!doc || typeof doc.jwks_uri !== 'string') {
+      throw new JwtError('idp-unreachable', `OIDC discovery missing jwks_uri: ${url}`);
+    }
+    if (doc.issuer && doc.issuer !== issuer) {
+      throw new JwtError(
+        'wrong-issuer',
+        `OIDC discovery issuer "${doc.issuer}" does not match configured "${issuer}"`,
+      );
+    }
+    discoveryCache.set(issuer, doc.jwks_uri);
+    return doc.jwks_uri;
+  }
+
+  async function fetchJwks(uri: string): Promise<readonly JwkKey[]> {
+    const cached = jwksCache.get(uri);
+    if (cached && now() - cached.fetchedAt < ttlMs) {
+      return cached.keys;
+    }
+    try {
+      const res = await fetchImpl(uri);
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const doc = (await res.json()) as { keys?: JwkKey[] };
+      const keys = Array.isArray(doc?.keys) ? doc.keys : [];
+      jwksCache.set(uri, { fetchedAt: now(), keys });
+      return keys;
+    } catch (err) {
+      throw new JwtError(
+        'idp-unreachable',
+        `JWKS fetch failed for ${uri}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  function selectKey(keys: readonly JwkKey[], decoded: DecodedJwt): JwkKey | undefined {
+    const kid = decoded.header.kid;
+    if (typeof kid === 'string' && kid.length > 0) {
+      return keys.find((k) => k.kid === kid);
+    }
+    // No kid — accept only when JWKS has exactly one key.
+    return keys.length === 1 ? keys[0] : undefined;
+  }
+
+  function invalidateJwks(uri: string): void {
+    jwksCache.delete(uri);
+  }
+
+  return {
+    name: 'oidc',
+    async sign(_envelope: AgentRpcEnvelope): Promise<RpcAuth> {
+      const auth: RpcAuth =
+        options.keyId !== undefined
+          ? { kind: 'oidc', token: options.token, keyId: options.keyId }
+          : { kind: 'oidc', token: options.token };
+      return auth;
+    },
+    async verify(
+      envelope: AgentRpcEnvelope,
+      peerConfig: OidcPeerConfig,
+    ): Promise<RpcAuthVerifyResult> {
+      const auth = envelope.auth;
+      if (!auth) {
+        return { ok: false, reason: 'missing-auth', message: 'envelope missing auth block' };
+      }
+      if (auth.kind !== 'oidc') {
+        return {
+          ok: false,
+          reason: 'wrong-kind',
+          message: `expected auth.kind "oidc", got "${auth.kind}"`,
+        };
+      }
+      let decoded: DecodedJwt;
+      try {
+        decoded = decodeJwt(auth.token);
+      } catch (err) {
+        return {
+          ok: false,
+          reason: 'malformed-token',
+          message: err instanceof Error ? err.message : String(err),
+        };
+      }
+      if (decoded.header.alg === 'none' || decoded.header.alg === 'None') {
+        return { ok: false, reason: 'alg-none', message: 'alg: none is not accepted' };
+      }
+      if (!SUPPORTED_ALGS.has(decoded.header.alg)) {
+        return {
+          ok: false,
+          reason: 'malformed-token',
+          message: `unsupported alg "${decoded.header.alg}"`,
+        };
+      }
+
+      // Required claims: iss + aud (exp/iat validated in checkTimeClaims).
+      if (typeof decoded.claims.iss !== 'string') {
+        return { ok: false, reason: 'missing-claim', message: 'claim `iss` is required' };
+      }
+      if (decoded.claims.aud === undefined) {
+        return { ok: false, reason: 'missing-claim', message: 'claim `aud` is required' };
+      }
+      if (decoded.claims.iss !== peerConfig.issuer) {
+        return {
+          ok: false,
+          reason: 'wrong-issuer',
+          message: `issuer "${decoded.claims.iss}" does not match peer config "${peerConfig.issuer}"`,
+        };
+      }
+      if (!audienceMatches(decoded.claims, peerConfig.audience)) {
+        return {
+          ok: false,
+          reason: 'wrong-audience',
+          message: `audience "${JSON.stringify(decoded.claims.aud)}" does not include "${peerConfig.audience}"`,
+        };
+      }
+
+      // Resolve JWKS — discovery → JWKS fetch.
+      let jwksUri: string;
+      try {
+        jwksUri = peerConfig.jwksUri ?? (await discoverJwksUri(peerConfig.issuer));
+      } catch (err) {
+        const code = err instanceof JwtError ? err.code : 'idp-unreachable';
+        return {
+          ok: false,
+          reason: code === 'wrong-issuer' ? 'wrong-issuer' : 'idp-unreachable',
+          message: err instanceof Error ? err.message : String(err),
+        };
+      }
+      let keys: readonly JwkKey[];
+      try {
+        keys = await fetchJwks(jwksUri);
+      } catch (err) {
+        return {
+          ok: false,
+          reason: 'idp-unreachable',
+          message: err instanceof Error ? err.message : String(err),
+        };
+      }
+      let key = selectKey(keys, decoded);
+      if (!key) {
+        // Rotation-race handling: invalidate + refetch once.
+        invalidateJwks(jwksUri);
+        try {
+          keys = await fetchJwks(jwksUri);
+        } catch (err) {
+          return {
+            ok: false,
+            reason: 'idp-unreachable',
+            message: err instanceof Error ? err.message : String(err),
+          };
+        }
+        key = selectKey(keys, decoded);
+      }
+      if (!key) {
+        return {
+          ok: false,
+          reason: 'bad-signature',
+          message: `no JWKS key matches kid "${decoded.header.kid ?? '<none>'}"`,
+        };
+      }
+
+      let sigOk = false;
+      try {
+        const cryptoKey = await importJwk(key, decoded.header.alg);
+        sigOk = await verifyJwtSignature(decoded, cryptoKey);
+      } catch (err) {
+        return {
+          ok: false,
+          reason: 'bad-signature',
+          message: `signature verify threw: ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+      if (!sigOk) {
+        return { ok: false, reason: 'bad-signature', message: 'JWT signature did not verify' };
+      }
+
+      const timeCheck = checkTimeClaims(decoded.claims, Math.floor(now() / 1000), clockSkewSec);
+      if (!timeCheck.ok) {
+        const reason =
+          timeCheck.code === 'expired'
+            ? 'expired'
+            : timeCheck.code === 'not-yet-valid'
+              ? 'not-yet-valid'
+              : 'missing-claim';
+        return {
+          ok: false,
+          reason,
+          message: `time-claim check failed: ${timeCheck.code} on ${timeCheck.field}`,
+        };
+      }
+
+      // Strict scope check — every required scope must be present.
+      const scopes = extractScopes(decoded.claims);
+      const required = peerConfig.scopes ?? [];
+      for (const s of required) {
+        if (!scopes.includes(s)) {
+          return {
+            ok: false,
+            reason: 'insufficient-scope',
+            message: `missing required scope "${s}"`,
+          };
+        }
+      }
+
+      const sub = typeof decoded.claims.sub === 'string' ? decoded.claims.sub : '';
+      const principal: RpcAuthPrincipal = {
+        subject: sub,
+        issuer: decoded.claims.iss as string,
+        audience: decoded.claims.aud as string | readonly string[],
+        scopes,
+        claims: decoded.claims as Readonly<Record<string, unknown>>,
+      };
+      return { ok: true, principal };
+    },
+  };
+}

--- a/packages/plugin-agent-rpc/src/auth/test-jwt.ts
+++ b/packages/plugin-agent-rpc/src/auth/test-jwt.ts
@@ -1,0 +1,110 @@
+/**
+ * Test-only helpers for minting JWTs against in-memory RSA key pairs.
+ * Not part of the public surface — colocated with the auth tests but
+ * scoped so it doesn't leak via the package's `index.ts` exports.
+ */
+
+interface SubtleLike {
+  generateKey(
+    alg: unknown,
+    extractable: boolean,
+    usages: readonly string[],
+  ): Promise<{ publicKey: unknown; privateKey: unknown }>;
+  exportKey(format: 'jwk', key: unknown): Promise<Record<string, unknown>>;
+  sign(alg: unknown, key: unknown, data: Uint8Array): Promise<ArrayBuffer>;
+}
+
+function subtle(): SubtleLike {
+  return (crypto as unknown as { subtle: SubtleLike }).subtle;
+}
+
+export interface TestKeyPair {
+  kid: string;
+  /** Public JWK with `kid` added and `alg: RS256`. */
+  publicJwk: Record<string, unknown>;
+  /** Private handle used by signing helpers. */
+  privateKey: unknown;
+}
+
+export async function generateRs256KeyPair(kid = 'test-kid'): Promise<TestKeyPair> {
+  const pair = await subtle().generateKey(
+    {
+      name: 'RSASSA-PKCS1-v1_5',
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: 'SHA-256',
+    },
+    true,
+    ['sign', 'verify'],
+  );
+  const jwk = await subtle().exportKey('jwk', pair.publicKey);
+  return {
+    kid,
+    publicJwk: { ...jwk, kid, alg: 'RS256', use: 'sig' },
+    privateKey: pair.privateKey,
+  };
+}
+
+function b64url(bytes: Uint8Array | string): string {
+  const u8 = typeof bytes === 'string' ? new TextEncoder().encode(bytes) : bytes;
+  let s = '';
+  for (let i = 0; i < u8.length; i += 1) s += String.fromCharCode(u8[i] as number);
+  return btoa(s).replace(/=+$/, '').replace(/\+/g, '-').replace(/\//g, '_');
+}
+
+export interface SignJwtOptions {
+  pair: TestKeyPair;
+  /** If true, omits `kid` from the header. */
+  omitKid?: boolean;
+  /** Override the `alg` header value — useful for alg:none tests. */
+  alg?: string;
+  /** Emit raw signing (for alg:none). */
+  emptySig?: boolean;
+  claims: Record<string, unknown>;
+}
+
+export async function signJwt(options: SignJwtOptions): Promise<string> {
+  const header: Record<string, unknown> = {
+    alg: options.alg ?? 'RS256',
+    typ: 'JWT',
+  };
+  if (!options.omitKid) header.kid = options.pair.kid;
+  const hEnc = b64url(JSON.stringify(header));
+  const cEnc = b64url(JSON.stringify(options.claims));
+  const signingInput = `${hEnc}.${cEnc}`;
+  if (options.emptySig) {
+    return `${signingInput}.`;
+  }
+  const sig = await subtle().sign(
+    { name: 'RSASSA-PKCS1-v1_5' },
+    options.pair.privateKey,
+    new TextEncoder().encode(signingInput),
+  );
+  return `${signingInput}.${b64url(new Uint8Array(sig))}`;
+}
+
+/**
+ * Minimal fetch mock. Returns a function that matches URLs and serves
+ * canned JSON. Anything unmatched throws.
+ */
+export function cannedFetch(
+  routes: Record<
+    string,
+    { status?: number; body: unknown } | (() => { status?: number; body: unknown })
+  >,
+): typeof globalThis.fetch {
+  return (async (input: unknown) => {
+    const url =
+      typeof input === 'string' ? input : String((input as { url?: string }).url ?? input);
+    const entry = routes[url];
+    if (!entry) throw new Error(`cannedFetch: no route for ${url}`);
+    const resolved = typeof entry === 'function' ? entry() : entry;
+    const status = resolved.status ?? 200;
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => resolved.body,
+      text: async () => JSON.stringify(resolved.body),
+    } as unknown as Response;
+  }) as unknown as typeof globalThis.fetch;
+}

--- a/packages/plugin-agent-rpc/src/auth/types.ts
+++ b/packages/plugin-agent-rpc/src/auth/types.ts
@@ -1,0 +1,94 @@
+/**
+ * RPC authentication provider contracts.
+ *
+ * Two providers ship with this package:
+ *
+ *   - `oidc` — validates a bearer JWT against an OIDC issuer's JWKS.
+ *     Signs outbound envelopes with a pre-acquired token handed in via
+ *     the factory (typical usage: Kubernetes projected token, Workload
+ *     Identity, an Okta session token etc.).
+ *
+ *   - `oauth2-client` — Client-Credentials flow. Fetches + caches an
+ *     access token from a token endpoint, auto-refreshes on expiry, and
+ *     signs outbound envelopes with it. Receive-path verification is
+ *     opaque introspection-free: we accept any well-formed JWT whose
+ *     signature validates against the issuer's JWKS and that carries
+ *     the required scopes.
+ *
+ * Providers operate ONLY on {@link RpcAuth} — they don't mutate the
+ * envelope body. The canonical sign payload for HMAC (`canonicalizeForSigning`)
+ * deliberately excludes `auth`, and the same rule applies here: tokens
+ * are bound to the peer + scope, not to envelope content. That keeps the
+ * verify path simple and lets an operator rotate tokens without rewriting
+ * every in-flight envelope.
+ *
+ * @since 1.2.0
+ */
+
+import type { AgentRpcEnvelope, RpcAuth } from '@declaragent/core';
+
+/**
+ * Typed rejection reasons emitted by {@link RpcAuthProvider.verify}. Plumbed
+ * through to the `rejected_events` table as the DLQ reason code so
+ * operators can filter on a stable vocabulary.
+ */
+export type RpcAuthRejectReason =
+  | 'missing-auth'
+  | 'wrong-kind'
+  | 'malformed-token'
+  | 'bad-signature'
+  | 'alg-none'
+  | 'missing-claim'
+  | 'expired'
+  | 'not-yet-valid'
+  | 'wrong-issuer'
+  | 'wrong-audience'
+  | 'insufficient-scope'
+  | 'idp-unreachable'
+  | 'config-error';
+
+export interface RpcAuthPrincipal {
+  /** The resolved subject claim (`sub`). */
+  readonly subject: string;
+  /** The issuer claim (`iss`). */
+  readonly issuer: string;
+  /** The audience claim (`aud`) — may be a single string or an array. */
+  readonly audience: string | readonly string[];
+  /** Scopes observed in the token. Whitespace-split `scope` or `scp`. */
+  readonly scopes: readonly string[];
+  /** Raw decoded claim set for provider-specific downstream use. */
+  readonly claims: Readonly<Record<string, unknown>>;
+}
+
+export type RpcAuthVerifyResult =
+  | { ok: true; principal: RpcAuthPrincipal }
+  | { ok: false; reason: RpcAuthRejectReason; message: string };
+
+/**
+ * Per-peer verify config. Providers cast this to their own internal shape.
+ * Shared shape — carries the `provider` discriminator + scopes both
+ * variants honor.
+ */
+export interface RpcAuthPeerConfigBase {
+  readonly provider: 'oidc' | 'oauth2-client';
+  readonly scopes?: readonly string[];
+}
+
+export interface RpcAuthProvider<Config extends RpcAuthPeerConfigBase = RpcAuthPeerConfigBase> {
+  readonly name: Config['provider'];
+  /**
+   * Produce the {@link RpcAuth} block to stamp onto an outbound envelope.
+   * The envelope is passed so providers that bind the token to a specific
+   * resource (e.g. DPoP) can read headers / payload; the OIDC/OAuth2
+   * providers shipped here don't use it.
+   */
+  sign(envelope: AgentRpcEnvelope): Promise<RpcAuth>;
+  /**
+   * Verify an inbound envelope's {@link RpcAuth} block against the peer
+   * config. MUST fail closed when the IdP is unreachable — see
+   * {@link RpcAuthRejectReason#idp-unreachable}.
+   */
+  verify(envelope: AgentRpcEnvelope, peerConfig: Config): Promise<RpcAuthVerifyResult>;
+  /** Optional teardown hook — close http clients, cancel refresh timers. */
+  close?(): Promise<void>;
+}

--- a/packages/plugin-agent-rpc/src/index.ts
+++ b/packages/plugin-agent-rpc/src/index.ts
@@ -32,8 +32,27 @@ export type {
 export { createAgentInboxAdapter, decodeFromWire } from './agent-inbox.js';
 export type {
   AgentInboxConfig,
+  AuthRejectSink,
+  AuthVerifyRegistry,
   CreateAgentInboxAdapterOptions,
 } from './agent-inbox.js';
+export { createOidcAuthProvider } from './auth/oidc.js';
+export type {
+  CreateOidcAuthProviderOptions,
+  OidcPeerConfig,
+} from './auth/oidc.js';
+export { createOAuth2ClientAuthProvider } from './auth/oauth2-client.js';
+export type {
+  CreateOAuth2ClientAuthProviderOptions,
+  OAuth2ClientPeerConfig,
+} from './auth/oauth2-client.js';
+export type {
+  RpcAuthPeerConfigBase,
+  RpcAuthPrincipal,
+  RpcAuthProvider,
+  RpcAuthRejectReason,
+  RpcAuthVerifyResult,
+} from './auth/types.js';
 export { createRespondHook } from './respond.js';
 export type { CreateRespondHookOptions } from './respond.js';
 export { createMemoryBus, createMemoryTransport } from './memory-transport.js';

--- a/packages/testkit/src/fleet-integration/rpc-auth.test.ts
+++ b/packages/testkit/src/fleet-integration/rpc-auth.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Item #4 · OIDC / OAuth2 on RPC envelopes — integration test.
+ *
+ * Boots a real Dex OIDC provider via docker-compose and exercises the
+ * two-agent round trip end-to-end:
+ *
+ *   1. Agent A mints an access token via Client-Credentials grant.
+ *   2. Stamps the envelope with `{ kind: 'oauth2-client', token }`.
+ *   3. Agent B's inbox resolves the peer config → OIDC provider →
+ *      JWKS verify → audit record.
+ *   4. Missing + wrong-audience tokens are DLQ'd under `auth-rejected`.
+ *
+ * ## How to run
+ *
+ * ```sh
+ * docker compose -f packages/testkit/test/fixtures/rpc-auth-dex.yml up -d
+ * RPC_AUTH_INTEGRATION=1 \
+ *   DEX_ISSUER=http://localhost:5556/dex \
+ *   bun test packages/testkit/src/fleet-integration/rpc-auth.test.ts
+ * ```
+ *
+ * Gated behind `RPC_AUTH_INTEGRATION=1` so unit-test runs aren't blocked
+ * on Docker availability.
+ *
+ * @since 1.2.0
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import type { AgentRpcEnvelope } from '@declaragent/core';
+import { createEventBus } from '@declaragent/core';
+import {
+  createAgentInboxAdapter,
+  createMemoryTransport,
+  createOAuth2ClientAuthProvider,
+  createOidcAuthProvider,
+} from '@declaragent/plugin-agent-rpc';
+
+const ENABLED = process.env.RPC_AUTH_INTEGRATION === '1';
+const ISSUER = process.env.DEX_ISSUER ?? 'http://localhost:5556/dex';
+const TOKEN_ENDPOINT = `${ISSUER}/token`;
+const JWKS_URI = `${ISSUER}/keys`;
+const CLIENT_ID = 'decl-agent-a';
+const CLIENT_SECRET = process.env.DEX_CLIENT_SECRET_A ?? 'decl-agent-a-secret';
+const AUDIENCE = CLIENT_ID; // Dex sets aud = client_id on client-credentials tokens
+
+const describeIntegration = ENABLED ? describe : describe.skip;
+
+function noopLogger() {
+  return {
+    debug() {},
+    info() {},
+    warn() {},
+    error() {},
+    child() {
+      return noopLogger();
+    },
+  };
+}
+
+describeIntegration('RPC auth — round-trip against Dex', () => {
+  beforeAll(async () => {
+    // Smoke-test the IdP is reachable so CI fails loudly instead of
+    // surfacing a confusing "token endpoint fetch failed".
+    const res = await fetch(`${ISSUER}/.well-known/openid-configuration`);
+    if (!res.ok) {
+      throw new Error(
+        `Dex not reachable at ${ISSUER}; start with \`docker compose -f packages/testkit/test/fixtures/rpc-auth-dex.yml up -d\``,
+      );
+    }
+  });
+
+  afterAll(() => {
+    // docker-compose is managed by the caller; nothing to tear down here.
+  });
+
+  test('two-agent round trip with a valid Client-Credentials token accepts', async () => {
+    const transport = createMemoryTransport();
+    const bus = createEventBus();
+    const received: AgentRpcEnvelope[] = [];
+
+    const signer = createOAuth2ClientAuthProvider({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+    });
+    const verifier = createOidcAuthProvider({ token: 'unused' });
+
+    const inbox = await createAgentInboxAdapter({
+      transport,
+      authRegistry: {
+        resolve() {
+          return {
+            config: {
+              provider: 'oidc',
+              issuer: ISSUER,
+              audience: AUDIENCE,
+              jwksUri: JWKS_URI,
+            },
+            provider: verifier,
+          };
+        },
+      },
+      onRequest(env) {
+        received.push(env);
+      },
+    }).create(
+      { id: 'inbox-b', agentId: 'peer-b' },
+      { bus, logger: noopLogger(), configDir: process.cwd() },
+    );
+    await inbox.start();
+
+    const envelope: AgentRpcEnvelope = {
+      version: 1,
+      kind: 'request',
+      messageId: crypto.randomUUID(),
+      correlationId: crypto.randomUUID(),
+      from: 'agent://peer-a',
+      to: 'agent://peer-b',
+      capability: 'echo',
+      replyTo: 'memory://agents.peer-a.responses',
+      payload: { hi: 'there' },
+      auth: await signer.sign({} as AgentRpcEnvelope),
+    };
+    await transport.publish('agents.peer-b.requests', envelope);
+
+    expect(received).toHaveLength(1);
+    expect(received[0]?.capability).toBe('echo');
+    await inbox.stop();
+  }, 20_000);
+
+  test('wrong-audience token is rejected via auth-rejected reject sink', async () => {
+    const transport = createMemoryTransport();
+    const bus = createEventBus();
+    const received: AgentRpcEnvelope[] = [];
+    const rejects: { reason: string }[] = [];
+
+    const signer = createOAuth2ClientAuthProvider({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+    });
+    const verifier = createOidcAuthProvider({ token: 'unused' });
+
+    const inbox = await createAgentInboxAdapter({
+      transport,
+      authRegistry: {
+        resolve() {
+          return {
+            config: {
+              provider: 'oidc',
+              issuer: ISSUER,
+              audience: 'wrong-audience',
+              jwksUri: JWKS_URI,
+            },
+            provider: verifier,
+          };
+        },
+      },
+      authRejectSink: ({ reason }) => {
+        rejects.push({ reason });
+      },
+      onRequest(env) {
+        received.push(env);
+      },
+    }).create(
+      { id: 'inbox-b', agentId: 'peer-b' },
+      { bus, logger: noopLogger(), configDir: process.cwd() },
+    );
+    await inbox.start();
+
+    const envelope: AgentRpcEnvelope = {
+      version: 1,
+      kind: 'request',
+      messageId: crypto.randomUUID(),
+      correlationId: crypto.randomUUID(),
+      from: 'agent://peer-a',
+      to: 'agent://peer-b',
+      capability: 'echo',
+      replyTo: 'memory://agents.peer-a.responses',
+      payload: {},
+      auth: await signer.sign({} as AgentRpcEnvelope),
+    };
+    await transport.publish('agents.peer-b.requests', envelope);
+
+    expect(received).toHaveLength(0);
+    expect(rejects).toHaveLength(1);
+    expect(rejects[0]?.reason).toBe('wrong-audience');
+    await inbox.stop();
+  }, 20_000);
+});

--- a/packages/testkit/test/fixtures/dex-config.yaml
+++ b/packages/testkit/test/fixtures/dex-config.yaml
@@ -1,0 +1,31 @@
+# Minimal Dex config for the RPC auth fleet-integration test. Client-
+# Credentials grant only — no browser login flow needed.
+issuer: http://localhost:5556/dex
+
+storage:
+  type: memory
+
+web:
+  http: 0.0.0.0:5556
+
+oauth2:
+  grantTypes:
+    - client_credentials
+  # Allowing clients to request a token without any extra scope keeps the
+  # provider config simple — the peer-side strict-scope check lives in
+  # our `RpcAuthProvider.verify()` implementation.
+  responseTypes:
+    - token
+  skipApprovalScreen: true
+
+staticClients:
+  - id: decl-agent-a
+    name: 'Declaragent agent A'
+    redirectURIs: []
+    secret: decl-agent-a-secret
+  - id: decl-agent-b
+    name: 'Declaragent agent B'
+    redirectURIs: []
+    secret: decl-agent-b-secret
+
+enablePasswordDB: false

--- a/packages/testkit/test/fixtures/rpc-auth-dex.yml
+++ b/packages/testkit/test/fixtures/rpc-auth-dex.yml
@@ -1,0 +1,28 @@
+version: '3.8'
+
+# Dex OIDC IdP fixture for RPC-auth integration tests (Item #4).
+#
+# Usage (from the repo root):
+#   docker compose -f packages/testkit/test/fixtures/rpc-auth-dex.yml up -d
+#   RPC_AUTH_INTEGRATION=1 DEX_ISSUER=http://localhost:5556/dex \
+#     bun test packages/testkit/src/fleet-integration/rpc-auth.test.ts
+#   docker compose -f packages/testkit/test/fixtures/rpc-auth-dex.yml down -v
+
+services:
+  dex:
+    image: ghcr.io/dexidp/dex:v2.39.1
+    container_name: declaragent-rpc-auth-dex
+    command: ['dex', 'serve', '/etc/dex/config.yaml']
+    ports:
+      - '5556:5556'
+    volumes:
+      - ./dex-config.yaml:/etc/dex/config.yaml:ro
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'wget -q -O- http://localhost:5556/dex/.well-known/openid-configuration >/dev/null',
+        ]
+      interval: 5s
+      timeout: 3s
+      retries: 20


### PR DESCRIPTION
## Summary
- Implements [Enterprise Production Plan §3 item #4](docs/ENTERPRISE_PRODUCTION_PLAN.md). Extends `RpcAuth` with two new variants (`oidc`, `oauth2-client`), ships concrete providers with WebCrypto-backed JWT verify, wires a verify call into the agent-inbox dispatch path, and emits `auth_check` audit records on every accept + reject.
- Independent of in-flight PRs. Targets `main` directly.

## What landed
- `packages/plugin-agent-rpc/src/auth/{types,jwt,oidc,oauth2-client,test-jwt}.ts` — provider interface + WebCrypto JWT (RS/PS/ES 256/384/512) + OIDC discovery with 5-min JWKS cache + OAuth2 Client-Credentials token fetch/refresh.
- `packages/core/src/rpc/envelope.ts` — `RpcAuth` gains `{kind:'oidc',token,keyId?}` and `{kind:'oauth2-client',token,scope?}`. `canonicalizeForSigning` still omits auth.
- `packages/core/src/rpc/peers-loader.ts` — per-peer `auth:` block with `provider` discriminant. `clientSecretRef` routes through the existing secrets resolver.
- `packages/core/src/audit/{types,index}.ts` + `core/src/index.ts` — `AuthCheckAuditRecord` added to `TenantAuditRecord` union.
- `packages/plugin-agent-rpc/src/agent-inbox.ts` — `AuthVerifyRegistry` lookup per envelope; emits `auth_check` on accept/reject; DLQ on reject with `auth-rejected` kind.
- `packages/testkit/src/fleet-integration/rpc-auth.test.ts` + docker-compose Dex fixture — integration test gated by `RPC_AUTH_INTEGRATION=1`.
- `docs-site/docs/reference/rpc.mdx` — new "Authenticated RPC" section.
- 28 new unit tests (18 OIDC + 7 OAuth2 + agent-inbox verify flow).

## Security notes
- `alg: none` rejected before any fetch; only RS/PS/ES 256/384/512 accepted (HS* absent).
- `exp`, `iat` required; `nbf` honored if present; 60s clock-skew window both sides (configurable).
- JWKS cache: 5-min TTL + single retry with cache-invalidate on `kid` miss (rotation race).
- Strict scope semantics — every scope in `peerConfig.scopes` must be in `scope`/`scp` claim.
- Fail-closed on IdP unreachable (typed `idp-unreachable` reject); JWKS cache provides transient-outage resilience.
- Typed reject reasons: `expired`, `malformed-token`, `alg-none`, `insufficient-scope`, `wrong-audience`, `wrong-issuer`, `idp-unreachable`, `bad-signature`, `missing-claim`, `missing-auth`, `wrong-kind`, `config-error`.

## Acceptance mapping (§3 #4)
1. ✅ OIDC-protected peer round trip — covered by `rpc-auth.test.ts` integration test + unit happy-path.
2. ✅ Malformed/expired token → `rejected_events` with `auth-rejected` — wired via `authRejectSink` in `agent-inbox`.
3. ✅ `auth_check` records on the hash chain — `emitAuthCheck` fires on accept AND reject; unit-tested.
4. ✅ Docs — new "Authenticated RPC" section.

## Files touched beyond spec list
- `packages/core/src/audit/types.ts` + `audit/index.ts` + `core/src/index.ts` — `AuthCheckAuditRecord` union entry.
- `packages/plugin-agent-rpc/src/agent-inbox.ts` — actual verify call-site (spec mentioned `envelope.ts` but dispatch lives here, where peer config is reachable).
- `packages/testkit/test/fixtures/{rpc-auth-dex.yml,dex-config.yaml}` — docker-compose for the integration test.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run build` — all 13 packages green
- [x] `bun test` — 2476 pass / 34 skip / 0 fail

## Follow-ups (not in this PR)
1. Wire `createDefaultSecretResolver` → `clientSecretRef` resolution into `declaragent up` daemon startup.
2. Provide a factory that builds `AuthVerifyRegistry` from `rpc-peers.yaml` + secrets during `up` boot — pieces are ready; integration is a separate ticket.
3. mTLS + SAML — separate workstreams per spec's Scope out section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)