### PR TITLE
feat(core,cli): per-tool rate limit (#7)

### DIFF
--- a/docs-site/docs/reference/agent-yaml.mdx
+++ b/docs-site/docs/reference/agent-yaml.mdx
@@ -51,6 +51,56 @@ tools:
 
 Full examples for every template live under [`templates/`](https://github.com/declaragent/declaragent/tree/main/templates) in the repo.
 
+## `tools.rateLimit` — per-tool throttle
+
+*Added 0.6.x (Enterprise Production Plan §3 Item #7).*
+
+The provider-level limiter caps how fast Declaragent talks to the LLM.
+That's not enough for a tool — especially `Bash`, which can shell out to
+`curl` and hammer a downstream API at whatever rate the LLM's tool-use
+loop can generate. `tools.rateLimit` adds a per-tool token bucket that
+fires **before** each invocation of `tool.execute()`. When the bucket is
+empty, the engine sleeps cooperatively until a token frees; the LLM turn
+stays alive and the next `tool_use` block in the same response simply
+waits its turn.
+
+```yaml
+name: concierge
+model: claude-sonnet-4-5
+systemPrompt: |
+  You are a careful concierge. Prefer Read/Grep over Bash.
+tools:
+  defaults:
+    - Read
+    - Grep
+    - Bash
+  rateLimit:
+    # Cap shell execution to 1 call/sec, no burst. A 10-call burst
+    # through this tool will take ~9 seconds end-to-end.
+    Bash:
+      rps: 1
+    # MCP tool names are namespaced `mcp__<server>__<tool>`.
+    mcp__github__list_issues:
+      rps: 5
+      burst: 10
+```
+
+**Fields.**
+
+| Field | Type | Required? | Description |
+| --- | --- | --- | --- |
+| `rps` | `number` (`> 0`) | yes | Steady-state rate in calls per second. Fractional values accepted (`0.5` = one call every two seconds). |
+| `burst` | `number` (`> 0`) | no | Max calls absorbed without throttling. Defaults to `rps`. Set to `2 * rps` for the classic token-bucket "1-second absorb" pattern. |
+
+**Observability.**
+- Every stall increments `declaragent_tool_rate_limit_waits_total{agent,tool}` and adds its observed wait to `declaragent_tool_rate_limit_wait_ms{agent,tool}` on the `/metrics` endpoint.
+- Waits that exceed 1 s emit a `rate_limited` audit record on the hash chain (tenant id, session id, tool name, configured rps/burst, observed wait). Short burst-absorption waits are silent to avoid chain bloat.
+
+**Scope.**
+- Tools not listed under `rateLimit` bypass the gate entirely — no overhead for unconfigured tools.
+- Per-user / per-tenant ceilings are **not** yet supported; see Enterprise Production Plan #5 multi-tenant quota work.
+- Dynamic rate adjustment based on 429 response headers is **not** supported; set a conservative `rps` up front.
+
 ## Fields documented post-slice 8
 
 The generated reference will additionally document:

--- a/packages/cli/src/up-cli.ts
+++ b/packages/cli/src/up-cli.ts
@@ -58,6 +58,7 @@ import {
   createSendMessageTool,
   createSqliteAuditSink,
   createSqliteSessionStore,
+  createToolRateLimitGate,
   defaultRateForProvider,
   dlqRoute,
   eventsRoute,
@@ -950,6 +951,26 @@ async function attachDispatcherToAgent(opts: {
   }
   extraTools.push(...plugins.tools);
 
+  // Enterprise Production Plan §3 Item #7 — per-tool token-bucket gate.
+  // Built only when `agent.yaml#tools.rateLimit` has at least one entry,
+  // to avoid allocating buckets for agents that opt out. Audit sink not
+  // wired here yet — `up` doesn't currently construct one; tenancy-aware
+  // callers that do can set it on `createEngine({ toolRateLimit })`.
+  const toolRateLimit =
+    Object.keys(loaded.toolRateLimits).length > 0
+      ? createToolRateLimitGate({
+          limits: loaded.toolRateLimits,
+          onWait: ({ tool, waitMs }) => {
+            runtime.metrics
+              .counter('declaragent.tool.rate_limit.waits_total', 'Tool rate-limit waits by tool')
+              .inc(1, { agent: spec.name, tool });
+            runtime.metrics
+              .counter('declaragent.tool.rate_limit.wait_ms', 'Cumulative ms waited per tool')
+              .inc(waitMs, { agent: spec.name, tool });
+          },
+        })
+      : undefined;
+
   const engine = createEngine({
     provider,
     tools: [
@@ -961,6 +982,7 @@ async function attachDispatcherToAgent(opts: {
     permissions: createPermissionGate({ mode: 'bypass', rules: [] }),
     hookRegistry,
     createChildSession: () => runtime.sessionStore.create(spec),
+    ...(toolRateLimit !== undefined && { toolRateLimit }),
   });
 
   // Per-skill circuit breakers (Slice 3 / PR 3.1). A skill that throws

--- a/packages/core/src/agents/load-agent.test.ts
+++ b/packages/core/src/agents/load-agent.test.ts
@@ -129,6 +129,53 @@ describe('loadAgent', () => {
     const loaded = await loadAgent({ agentDir: dir });
     expect(loaded.toolNames).toEqual([]);
   });
+
+  test('toolRateLimits parses tools.rateLimit and defaults burst to rps', async () => {
+    writeFileSync(
+      join(dir, 'agent.yaml'),
+      [
+        'name: x',
+        'model: y',
+        'systemPrompt: z',
+        'tools:',
+        '  defaults: [Bash, Read]',
+        '  rateLimit:',
+        '    Bash: { rps: 1 }',
+        '    Read: { rps: 10, burst: 30 }',
+        '',
+      ].join('\n'),
+    );
+    const loaded = await loadAgent({ agentDir: dir });
+    expect(loaded.toolRateLimits).toEqual({
+      Bash: { rps: 1, burst: 1 },
+      Read: { rps: 10, burst: 30 },
+    });
+  });
+
+  test('toolRateLimits is empty when rateLimit block omitted', async () => {
+    writeFileSync(
+      join(dir, 'agent.yaml'),
+      'name: x\nmodel: y\nsystemPrompt: z\ntools:\n  defaults: [Read]\n',
+    );
+    const loaded = await loadAgent({ agentDir: dir });
+    expect(loaded.toolRateLimits).toEqual({});
+  });
+
+  test('rejects rateLimit with rps <= 0', async () => {
+    writeFileSync(
+      join(dir, 'agent.yaml'),
+      [
+        'name: x',
+        'model: y',
+        'systemPrompt: z',
+        'tools:',
+        '  rateLimit:',
+        '    Bash: { rps: 0 }',
+        '',
+      ].join('\n'),
+    );
+    await expect(loadAgent({ agentDir: dir })).rejects.toThrow(/rateLimit|rps|validation/i);
+  });
 });
 
 describe('composeSystemPromptWithSkills', () => {

--- a/packages/core/src/agents/load-agent.ts
+++ b/packages/core/src/agents/load-agent.ts
@@ -66,6 +66,23 @@ const agentYamlSchema = z
     tools: z
       .object({
         defaults: z.array(z.string()).optional(),
+        /**
+         * Enterprise Production Plan §3 Item #7 — per-tool rate limit
+         * config. Keys are tool names (`Bash`, `Write`, `mcp__github__list_issues`, …);
+         * values are `{ rps, burst? }`. Omitted tools are uncapped.
+         * `burst` defaults to `rps` at load time (see `ToolRateLimitGate`).
+         *
+         * @since 0.6.x
+         */
+        rateLimit: z
+          .record(
+            z.string().min(1),
+            z.object({
+              rps: z.number().positive(),
+              burst: z.number().positive().optional(),
+            }),
+          )
+          .optional(),
       })
       .passthrough()
       .optional(),
@@ -74,11 +91,27 @@ const agentYamlSchema = z
 
 export type AgentYaml = z.infer<typeof agentYamlSchema>;
 
+/**
+ * Per-tool rate-limit config as loaded from `agent.yaml#tools.rateLimit`.
+ * `burst` is normalised to a concrete value at load time (default = rps).
+ *
+ * @since 0.6.x — Enterprise Production Plan §3 Item #7
+ */
+export interface LoadedToolRateLimit {
+  readonly rps: number;
+  readonly burst: number;
+}
+
 export interface LoadedAgent {
   readonly spec: AgentSpec;
   readonly skills: readonly Skill[];
   /** Tool names declared under `tools.defaults`. CLI resolves to actual `Tool` objects. */
   readonly toolNames: readonly string[];
+  /**
+   * Per-tool rate limits parsed from `tools.rateLimit`. Empty when the
+   * block is omitted. CLI passes this straight to `createToolRateLimitGate`.
+   */
+  readonly toolRateLimits: Readonly<Record<string, LoadedToolRateLimit>>;
   readonly agentDir: string;
   readonly agentYamlPath: string;
   /** Lookup-name collisions surfaced by the skill loader; callers may warn. */
@@ -161,10 +194,25 @@ export async function loadAgent(options: LoadAgentOptions): Promise<LoadedAgent>
     ...(cfg.subagentDepthCap !== undefined && { subagentDepthCap: cfg.subagentDepthCap }),
   };
 
+  // Normalise the rate-limit block. Missing `burst` defaults to `rps`
+  // (matches ToolRateLimitGate behaviour — a full second of steady-state
+  // calls absorbable without sleeping).
+  const rawRateLimit = cfg.tools?.rateLimit;
+  const toolRateLimits: Record<string, LoadedToolRateLimit> = {};
+  if (rawRateLimit) {
+    for (const [toolName, entry] of Object.entries(rawRateLimit)) {
+      toolRateLimits[toolName] = {
+        rps: entry.rps,
+        burst: entry.burst ?? entry.rps,
+      };
+    }
+  }
+
   return {
     spec,
     skills: skillLoad.skills,
     toolNames: cfg.tools?.defaults ?? [],
+    toolRateLimits,
     agentDir,
     agentYamlPath,
     skillConflicts: skillLoad.conflicts,

--- a/packages/core/src/audit/index.ts
+++ b/packages/core/src/audit/index.ts
@@ -3,6 +3,7 @@ export type {
   EraseOptions,
   ErasedAuditRecord,
   QuotaExceededAuditRecord,
+  RateLimitedAuditRecord,
   RetentionPruneOptions,
   StoredAuditEntry,
   TenantAuditQuery,

--- a/packages/core/src/audit/types.ts
+++ b/packages/core/src/audit/types.ts
@@ -104,6 +104,32 @@ export interface AuthCheckAuditRecord {
 }
 
 /**
+ * Per-tool rate-limit stall. Emitted by the {@link import('../tools/rate-limit-gate.js').ToolRateLimitGate}
+ * when a tool invocation had to wait for a token longer than the configured
+ * `auditThresholdMs` (default 1000 ms). Short waits are silent — auditing
+ * every few-ms blip would bloat the chain without operational value.
+ *
+ * @since 0.6.x — Enterprise Production Plan §3 Item #7
+ */
+export interface RateLimitedAuditRecord {
+  kind: 'rate_limited';
+  ts: number;
+  tenantId: string;
+  /** Tool name whose bucket was empty. */
+  tool: string;
+  /** Configured steady-state rate (rps). */
+  rps: number;
+  /** Configured burst capacity. */
+  burst: number;
+  /** Wall-clock time the caller waited, in ms. */
+  waitMs: number;
+  /** Session the call originated from (when available). */
+  sessionId?: string;
+  /** Correlation id threaded through from the originating event. */
+  correlationId?: string;
+}
+
+/**
  * Erasure tombstone — surfaced by queries in place of records that
  * `TenantAuditSink.erase()` has scrubbed. Keeps the hash-chain verifier
  * able to confirm continuity even after right-to-erasure requests.
@@ -138,6 +164,7 @@ export type TenantAuditRecord =
   | TenantBoundaryAuditRecord
   | QuotaExceededAuditRecord
   | AuthCheckAuditRecord
+  | (RateLimitedAuditRecord & { tenantId: string })
   | ErasedAuditRecord;
 
 /** @since 1.0.0 */

--- a/packages/core/src/engine/engine.ts
+++ b/packages/core/src/engine/engine.ts
@@ -7,6 +7,7 @@ import { shouldEscalate } from '../permission/gate.js';
 import { QuotaExceededError, type QuotaTracker } from '../tenancy/quota.js';
 import { stampTenantId } from '../tenancy/stamp.js';
 import type { TenantContext } from '../tenancy/types.js';
+import type { ToolRateLimitGate } from '../tools/rate-limit-gate.js';
 import type {
   RunAgent,
   RunAgentInput,
@@ -145,6 +146,15 @@ export interface EngineConfig {
    * loop — the permission gate's escalation policy is unchanged.
    */
   quotas?: QuotaTracker;
+  /**
+   * Enterprise Production Plan §3 Item #7. Per-tool token-bucket gate.
+   * When supplied, each tool's `.execute()` is preceded by
+   * `toolRateLimit.acquire(tool.name, ctx)` — capped tools sleep until a
+   * token frees; uncapped tools pass through with zero overhead. Audit
+   * emission is the gate's responsibility; the engine only supplies the
+   * tenant + session + correlation context.
+   */
+  toolRateLimit?: ToolRateLimitGate;
 }
 
 export interface Engine {
@@ -229,6 +239,7 @@ export function createEngine(config: EngineConfig): Engine {
     bus,
     tenant,
     quotas,
+    toolRateLimit,
     logger = NOOP_LOGGER,
   } = config;
   const maxIterations = config.maxIterations ?? DEFAULT_MAX_ITERATIONS;
@@ -474,6 +485,26 @@ export function createEngine(config: EngineConfig): Engine {
                 continue;
               }
               throw err;
+            }
+          }
+
+          // Enterprise Production Plan §3 Item #7 — per-tool rate limit
+          // gate. Fires BEFORE `.execute()`. Uncapped tools return 0
+          // immediately so the hot path is free. Audit emission (for
+          // waits > 1s) lives inside the gate. Placed after permission
+          // + quota so a denied call doesn't burn a token.
+          if (toolRateLimit) {
+            try {
+              await toolRateLimit.acquire(tool.name, {
+                tenantId: tenant?.id ?? 'default',
+                sessionId: session.id,
+                ...(input.causedBy !== undefined && { correlationId: input.causedBy }),
+              });
+            } catch (err) {
+              turnLogger.warn('tool.rate_limit.error', {
+                toolName: tool.name,
+                message: err instanceof Error ? err.message : String(err),
+              });
             }
           }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -198,6 +198,7 @@ export {
   Read,
   Write,
   createSendMessageTool,
+  createToolRateLimitGate,
   permissionKeyFor as sendMessagePermissionKey,
 } from './tools/index.js';
 export type {
@@ -217,6 +218,10 @@ export type {
   CreateSendMessageToolDeps,
   SendMessageInput,
   SendMessageOutput,
+  ToolRateLimitAcquireContext,
+  ToolRateLimitConfig,
+  ToolRateLimitGate,
+  ToolRateLimitGateOptions,
   WriteInput,
   WriteOutput,
 } from './tools/index.js';
@@ -481,7 +486,12 @@ export type {
   SkillTier,
 } from './skills/index.js';
 export { AgentConfigError, composeSystemPromptWithSkills, loadAgent } from './agents/load-agent.js';
-export type { AgentYaml, LoadAgentOptions, LoadedAgent } from './agents/load-agent.js';
+export type {
+  AgentYaml,
+  LoadAgentOptions,
+  LoadedAgent,
+  LoadedToolRateLimit,
+} from './agents/load-agent.js';
 export {
   DEFAULT_PLUGIN_STORE_FILE,
   PluginActivationError,

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -10,6 +10,13 @@ export { Grep } from './grep.js';
 export type { GrepInput, GrepMatch, GrepOutput } from './grep.js';
 export { Read } from './read.js';
 export type { ReadInput, ReadOutput } from './read.js';
+export { createToolRateLimitGate } from './rate-limit-gate.js';
+export type {
+  ToolRateLimitAcquireContext,
+  ToolRateLimitConfig,
+  ToolRateLimitGate,
+  ToolRateLimitGateOptions,
+} from './rate-limit-gate.js';
 export { createSendMessageTool, permissionKeyFor } from './send-message.js';
 export type {
   CreateSendMessageToolDeps,

--- a/packages/core/src/tools/rate-limit-gate.test.ts
+++ b/packages/core/src/tools/rate-limit-gate.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, test } from 'bun:test';
+import type {
+  RateLimitedAuditRecord,
+  StoredAuditEntry,
+  TenantAuditRecord,
+  TenantAuditSink,
+  VerifyReport,
+} from '../audit/types.js';
+import { createToolRateLimitGate } from './rate-limit-gate.js';
+
+// ── fake clock + sleep (mirrors providers/rate-limit.test.ts) ─────────────
+
+function makeFakeClock(): { now: () => number; advance: (ms: number) => void } {
+  let t = 1_000_000;
+  return {
+    now: () => t,
+    advance: (ms: number) => {
+      t += ms;
+    },
+  };
+}
+
+function makeFakeSleep(clock: { advance: (ms: number) => void }): {
+  sleep: (ms: number) => Promise<void>;
+  waits: number[];
+} {
+  const waits: number[] = [];
+  return {
+    waits,
+    sleep: async (ms: number) => {
+      waits.push(ms);
+      clock.advance(ms);
+    },
+  };
+}
+
+function makeRecordingSink(): {
+  sink: TenantAuditSink;
+  recorded: TenantAuditRecord[];
+} {
+  const recorded: TenantAuditRecord[] = [];
+  const sink: TenantAuditSink = {
+    async record(r: TenantAuditRecord) {
+      recorded.push(r);
+    },
+    async query(): Promise<readonly StoredAuditEntry[]> {
+      return [];
+    },
+    async erase(): Promise<number> {
+      return 0;
+    },
+    async verify(): Promise<VerifyReport> {
+      return { ok: true, totalEntries: 0, verifiedEntries: 0, violations: [] };
+    },
+    async prune(): Promise<number> {
+      return 0;
+    },
+    async close() {
+      /* no-op */
+    },
+  };
+  return { sink, recorded };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe('ToolRateLimitGate', () => {
+  test('under-limit passes immediately', async () => {
+    const clock = makeFakeClock();
+    const sleep = makeFakeSleep(clock);
+    const gate = createToolRateLimitGate({
+      limits: { Bash: { rps: 10, burst: 5 } },
+      now: clock.now,
+      sleep: sleep.sleep,
+    });
+    for (let i = 0; i < 5; i += 1) {
+      expect(await gate.acquire('Bash', { tenantId: 't1' })).toBe(0);
+    }
+    expect(sleep.waits).toHaveLength(0);
+  });
+
+  test('unconfigured tool is uncapped (returns 0 without touching state)', async () => {
+    const clock = makeFakeClock();
+    const sleep = makeFakeSleep(clock);
+    const gate = createToolRateLimitGate({
+      limits: { Bash: { rps: 1 } },
+      now: clock.now,
+      sleep: sleep.sleep,
+    });
+    for (let i = 0; i < 100; i += 1) {
+      expect(await gate.acquire('Read', { tenantId: 't1' })).toBe(0);
+    }
+    expect(sleep.waits).toHaveLength(0);
+    expect(gate.has('Read')).toBe(false);
+    expect(gate.has('Bash')).toBe(true);
+  });
+
+  test('over-limit cooperatively sleeps until a token frees', async () => {
+    const clock = makeFakeClock();
+    const sleep = makeFakeSleep(clock);
+    const gate = createToolRateLimitGate({
+      limits: { Bash: { rps: 2, burst: 1 } },
+      now: clock.now,
+      sleep: sleep.sleep,
+    });
+    // First call drains the 1-token burst immediately.
+    expect(await gate.acquire('Bash', { tenantId: 't1' })).toBe(0);
+    // Second call waits 500ms (1 token at 2 rps = 500ms).
+    const waited = await gate.acquire('Bash', { tenantId: 't1' });
+    expect(waited).toBeGreaterThanOrEqual(500);
+    expect(sleep.waits).toEqual([waited]);
+  });
+
+  test('acceptance #1: Bash capped at 1rps, 10 calls take ≥ 9s (deterministic clock)', async () => {
+    const clock = makeFakeClock();
+    const sleep = makeFakeSleep(clock);
+    const gate = createToolRateLimitGate({
+      limits: { Bash: { rps: 1 } }, // burst defaults to rps (=1)
+      now: clock.now,
+      sleep: sleep.sleep,
+    });
+
+    const start = clock.now();
+    for (let i = 0; i < 10; i += 1) {
+      await gate.acquire('Bash', { tenantId: 't1' });
+    }
+    const elapsedMs = clock.now() - start;
+
+    // First call consumes the burst; each of the remaining 9 waits
+    // ~1000 ms. Expected total ≈ 9000 ms.
+    expect(elapsedMs).toBeGreaterThanOrEqual(9_000);
+    expect(sleep.waits).toHaveLength(9);
+  });
+
+  test('acceptance #1 (wall-clock variant): real timers, 1rps × 10 takes ≥ 9s', async () => {
+    const gate = createToolRateLimitGate({
+      limits: { Bash: { rps: 1 } },
+    });
+
+    const started = performance.now();
+    for (let i = 0; i < 10; i += 1) {
+      await gate.acquire('Bash', { tenantId: 't1' });
+    }
+    const elapsedMs = performance.now() - started;
+
+    // Token bucket: 1 burst + 9 refill waits at ~1000 ms each.
+    // Allow a tiny floor of 8900 ms to absorb setTimeout slop on CI.
+    expect(elapsedMs).toBeGreaterThanOrEqual(8_900);
+  }, 15_000);
+
+  test('audit record fires only when wait > auditThresholdMs (default 1s)', async () => {
+    const clock = makeFakeClock();
+    const sleep = makeFakeSleep(clock);
+    const { sink, recorded } = makeRecordingSink();
+    const gate = createToolRateLimitGate({
+      // rps=1, burst=1 → waits between calls are ~1000 ms which is
+      // NOT strictly greater than the default 1000 ms threshold.
+      // So drop rps to 0.5 to force 2000 ms waits that clear the bar.
+      limits: { Bash: { rps: 0.5, burst: 1 } },
+      auditSink: sink,
+      now: clock.now,
+      sleep: sleep.sleep,
+    });
+
+    // Burst absorbs the first call — no audit.
+    await gate.acquire('Bash', { tenantId: 't1', sessionId: 's1', correlationId: 'c1' });
+    expect(recorded).toHaveLength(0);
+
+    // Second call waits ~2000 ms > 1000 ms threshold → audits.
+    await gate.acquire('Bash', { tenantId: 't1', sessionId: 's1', correlationId: 'c1' });
+    expect(recorded).toHaveLength(1);
+    const rec = recorded[0] as RateLimitedAuditRecord;
+    expect(rec.kind).toBe('rate_limited');
+    expect(rec.tool).toBe('Bash');
+    expect(rec.rps).toBe(0.5);
+    expect(rec.burst).toBe(1);
+    expect(rec.tenantId).toBe('t1');
+    expect(rec.sessionId).toBe('s1');
+    expect(rec.correlationId).toBe('c1');
+    expect(rec.waitMs).toBeGreaterThan(1_000);
+  });
+
+  test('audit record is suppressed when wait ≤ threshold', async () => {
+    const clock = makeFakeClock();
+    const sleep = makeFakeSleep(clock);
+    const { sink, recorded } = makeRecordingSink();
+    const gate = createToolRateLimitGate({
+      limits: { Bash: { rps: 10, burst: 1 } },
+      auditSink: sink,
+      auditThresholdMs: 1_000,
+      now: clock.now,
+      sleep: sleep.sleep,
+    });
+
+    // Burst + 5 more calls at 10 rps → waits of ~100 ms each, well
+    // under the 1000 ms threshold.
+    for (let i = 0; i < 6; i += 1) {
+      await gate.acquire('Bash', { tenantId: 't1' });
+    }
+    expect(recorded).toHaveLength(0);
+  });
+
+  test('audit persistence errors are swallowed (never block the call)', async () => {
+    const clock = makeFakeClock();
+    const sleep = makeFakeSleep(clock);
+    const failingSink: TenantAuditSink = {
+      async record() {
+        throw new Error('sqlite offline');
+      },
+      async query() {
+        return [];
+      },
+      async erase() {
+        return 0;
+      },
+      async verify() {
+        return { ok: true, totalEntries: 0, verifiedEntries: 0, violations: [] };
+      },
+      async prune() {
+        return 0;
+      },
+      async close() {},
+    };
+    const gate = createToolRateLimitGate({
+      limits: { Bash: { rps: 0.5, burst: 1 } },
+      auditSink: failingSink,
+      now: clock.now,
+      sleep: sleep.sleep,
+    });
+    await gate.acquire('Bash', { tenantId: 't1' }); // burst
+    await expect(gate.acquire('Bash', { tenantId: 't1' })).resolves.toBeGreaterThan(1_000);
+  });
+
+  test('onWait hook fires with observed wait', async () => {
+    const clock = makeFakeClock();
+    const sleep = makeFakeSleep(clock);
+    const waits: Array<{ tool: string; waitMs: number }> = [];
+    const gate = createToolRateLimitGate({
+      limits: { Bash: { rps: 2, burst: 1 } },
+      onWait: (ev) => waits.push(ev),
+      now: clock.now,
+      sleep: sleep.sleep,
+    });
+    await gate.acquire('Bash', { tenantId: 't1' }); // burst → no onWait
+    await gate.acquire('Bash', { tenantId: 't1' });
+    expect(waits).toHaveLength(1);
+    expect(waits[0]?.tool).toBe('Bash');
+    expect(waits[0]?.waitMs).toBeGreaterThanOrEqual(500);
+  });
+
+  test('rejects non-positive rps with a helpful message', () => {
+    expect(() => createToolRateLimitGate({ limits: { Bash: { rps: 0 } } })).toThrow(
+      /Bash.*rps must be > 0/,
+    );
+    expect(() => createToolRateLimitGate({ limits: { Bash: { rps: -1 } } })).toThrow(
+      /Bash.*rps must be > 0/,
+    );
+  });
+
+  test('burst defaults to rps when omitted', async () => {
+    const clock = makeFakeClock();
+    const sleep = makeFakeSleep(clock);
+    const gate = createToolRateLimitGate({
+      limits: { Bash: { rps: 3 } },
+      now: clock.now,
+      sleep: sleep.sleep,
+    });
+    // Without explicit burst, bucket should absorb 3 immediate calls.
+    for (let i = 0; i < 3; i += 1) {
+      expect(await gate.acquire('Bash', { tenantId: 't1' })).toBe(0);
+    }
+    expect(sleep.waits).toHaveLength(0);
+  });
+});

--- a/packages/core/src/tools/rate-limit-gate.ts
+++ b/packages/core/src/tools/rate-limit-gate.ts
@@ -1,0 +1,168 @@
+/**
+ * Per-tool rate limiting (Enterprise Production Plan §3 Item #7).
+ *
+ * The provider-level limiter in `../providers/rate-limit.ts` caps how
+ * fast we talk to the LLM. A tool — especially `Bash`, which can shell
+ * out to `curl` — can still hammer downstream systems at whatever rate
+ * the LLM's tool_use loop generates. Buyers want a per-tool ceiling.
+ *
+ * Mechanics are identical to the provider limiter: token bucket with a
+ * configurable steady-state `rps` and `burst` capacity. We reuse
+ * {@link ProviderTokenBucket} directly rather than reimplement. The
+ * only new surface is:
+ *   - A facade (`ToolRateLimitGate`) keyed on tool name so a single
+ *     config object can manage N tools.
+ *   - A `rate_limited` audit record that fires when the wait exceeds
+ *     a configurable threshold (default 1 s). Short, pure-burst-absorption
+ *     waits stay silent so the chain doesn't bloat.
+ *
+ * Injected clock + sleep are preserved so tests can drive time
+ * deterministically — the provider limiter's tests use the same
+ * pattern and this module mirrors them.
+ *
+ * @since 0.6.x — Enterprise Production Plan §3 Item #7
+ */
+
+import type { RateLimitedAuditRecord, TenantAuditSink } from '../audit/types.js';
+import { ProviderTokenBucket } from '../providers/rate-limit.js';
+
+/** Per-tool rate-limit configuration as surfaced in `agent.yaml`. */
+export interface ToolRateLimitConfig {
+  /** Steady-state rate in calls per second. Must be > 0. */
+  rps: number;
+  /**
+   * Max calls the bucket can absorb without throttling. Defaults to
+   * `rps` (i.e. a full second of steady-state calls). Operators who
+   * want the classic "2× rps" burst behaviour set it explicitly.
+   */
+  burst?: number;
+}
+
+/** Context passed to `acquire()` — everything the audit record needs. */
+export interface ToolRateLimitAcquireContext {
+  /** Tenant on whose behalf the tool is running. Audit sinks are per-tenant. */
+  tenantId: string;
+  /** Session id, if available. Lets operators correlate stalls to a turn. */
+  sessionId?: string;
+  /** Correlation id of the originating event, when known. */
+  correlationId?: string;
+}
+
+/** Options accepted by {@link createToolRateLimitGate}. */
+export interface ToolRateLimitGateOptions {
+  /** Tool name → config. Tools not in this map are uncapped. */
+  limits: Readonly<Record<string, ToolRateLimitConfig>>;
+  /**
+   * Audit sink for `rate_limited` records. Optional — when absent, the
+   * gate still throttles, it just doesn't record. The sink's `record()`
+   * errors are swallowed (we never block a tool on audit persistence).
+   */
+  auditSink?: TenantAuditSink;
+  /**
+   * Waits shorter than this are silent. Default 1000 ms — matches the
+   * spec's "emit a rate_limited audit record if the wait exceeds 1s".
+   */
+  auditThresholdMs?: number;
+  /**
+   * Injected wall clock. Default `Date.now`. Tests override for
+   * deterministic time.
+   */
+  now?: () => number;
+  /** Injected sleep. Default `setTimeout`. Tests override with a fake. */
+  sleep?: (ms: number) => Promise<void>;
+  /**
+   * Fires whenever a tool call waited for a token. Mirrors the provider
+   * wrapper's `onWait` — the CLI bumps Prometheus counters from here.
+   */
+  onWait?: (event: { tool: string; waitMs: number }) => void;
+}
+
+/**
+ * Gate returned by {@link createToolRateLimitGate}.
+ *
+ * Thin facade: `acquire(tool, ctx)` consumes one token for `tool` and
+ * returns the ms waited (0 = immediate). If the wait exceeds
+ * `auditThresholdMs`, a `rate_limited` audit record is persisted.
+ *
+ * Tools that are not in the configured `limits` map bypass the gate
+ * entirely — `acquire()` returns 0 without touching any state. This
+ * preserves pre-rate-limit behaviour for unconfigured tools.
+ */
+export interface ToolRateLimitGate {
+  /**
+   * Reserve one slot for `toolName`. Returns the ms waited — callers
+   * don't need to act on it; the gate's internal sleep has already
+   * elapsed. Provided for metrics / diagnostics.
+   */
+  acquire(toolName: string, ctx: ToolRateLimitAcquireContext): Promise<number>;
+  /** True when `toolName` has a configured limit. */
+  has(toolName: string): boolean;
+}
+
+const DEFAULT_AUDIT_THRESHOLD_MS = 1_000;
+
+export function createToolRateLimitGate(options: ToolRateLimitGateOptions): ToolRateLimitGate {
+  const { limits, auditSink, onWait } = options;
+  const auditThresholdMs = options.auditThresholdMs ?? DEFAULT_AUDIT_THRESHOLD_MS;
+  const now = options.now ?? Date.now;
+  const sleep = options.sleep;
+
+  const buckets = new Map<string, ProviderTokenBucket>();
+  const configs = new Map<string, { rps: number; burst: number }>();
+  for (const [toolName, cfg] of Object.entries(limits)) {
+    if (!(cfg.rps > 0)) {
+      throw new Error(`tools.rateLimit[${toolName}]: rps must be > 0 (got ${String(cfg.rps)})`);
+    }
+    const burst = Math.max(1, cfg.burst ?? cfg.rps);
+    const bucketOpts: ConstructorParameters<typeof ProviderTokenBucket>[0] = {
+      ratePerSec: cfg.rps,
+      burst,
+      now,
+      ...(sleep !== undefined && { sleep }),
+    };
+    buckets.set(toolName, new ProviderTokenBucket(bucketOpts));
+    configs.set(toolName, { rps: cfg.rps, burst });
+  }
+
+  async function acquire(toolName: string, ctx: ToolRateLimitAcquireContext): Promise<number> {
+    const bucket = buckets.get(toolName);
+    if (!bucket) return 0;
+    const waitMs = await bucket.take();
+    if (waitMs > 0 && onWait) {
+      try {
+        onWait({ tool: toolName, waitMs });
+      } catch {
+        // Metrics hook misbehaved; the tool call already waited. Swallow.
+      }
+    }
+    if (waitMs > auditThresholdMs && auditSink) {
+      const cfg = configs.get(toolName);
+      if (cfg) {
+        const record: RateLimitedAuditRecord & { tenantId: string } = {
+          kind: 'rate_limited',
+          ts: now(),
+          tenantId: ctx.tenantId,
+          tool: toolName,
+          rps: cfg.rps,
+          burst: cfg.burst,
+          waitMs,
+          ...(ctx.sessionId !== undefined && { sessionId: ctx.sessionId }),
+          ...(ctx.correlationId !== undefined && { correlationId: ctx.correlationId }),
+        };
+        try {
+          await auditSink.record(record);
+        } catch {
+          // Audit persistence must never block the tool loop.
+        }
+      }
+    }
+    return waitMs;
+  }
+
+  return {
+    acquire,
+    has(toolName) {
+      return buckets.has(toolName);
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Implements [Enterprise Production Plan §3 item #7](docs/ENTERPRISE_PRODUCTION_PLAN.md). Adds a cooperative rate-limit gate in front of `tool.execute()`, driven by a new `tools.rateLimit` block in `agent.yaml`. Re-uses `ProviderTokenBucket`.
- Independent of in-flight PRs. Targets `main` directly.

## What landed
- `packages/core/src/tools/rate-limit-gate.ts` — `createToolRateLimitGate` factory, keyed by tool name. `acquire()` blocks with cooperative sleep; emits `rate_limited` audit record when wait exceeds 1s (configurable).
- `packages/core/src/tools/rate-limit-gate.test.ts` — 11 tests including the wall-clock acceptance test (10 executions @ 1rps takes ≥ 9s).
- `packages/core/src/audit/{types,index}.ts` — `RateLimitedAuditRecord` added to `TenantAuditRecord` union.
- `packages/core/src/agents/load-agent.ts` — `tools.rateLimit: { [ToolName]: { rps: number; burst?: number } }` schema; `burst` defaults to `rps` when unset.
- `packages/core/src/engine/engine.ts` — engine config gains `toolRateLimit?: ToolRateLimitGate`; gate fires after permission + quota, before `drainToolEvents`. Gate errors log but never fail the call.
- `packages/cli/src/up-cli.ts` — constructs the gate from `loaded.toolRateLimits` when non-empty; `onWait` bumps `declaragent.tool.rate_limit.{waits_total,wait_ms}` metrics.
- `docs-site/docs/reference/agent-yaml.mdx` — new `tools.rateLimit` section with YAML example + observability + scope notes.

## Acceptance mapping (§3 #7)
1. ✅ Config caps `Bash` at 1 rps; 10 executions takes ≥ 9s — covered by both fake-clock (asserts `elapsedMs >= 9_000` and exactly 9 sleeps) and real-clock (`>= 8900 ms` within 15s timeout) acceptance tests.
2. ✅ Over-limit calls emit `rate_limited` audit rows — record shape (`tenantId`, `sessionId`, `correlationId`, `rps`, `burst`, `waitMs`) asserted; suppression test confirms sub-threshold waits stay silent.
3. ✅ Docs — new `tools.rateLimit` section.

## Config example
```yaml
tools:
  defaults:
    - Read
    - Grep
    - Bash
  rateLimit:
    Bash:
      rps: 1
    mcp__github__list_issues:
      rps: 5
      burst: 10
```

## Test plan
- [x] `bun run typecheck` — all 13 packages green
- [x] `bun run lint` — clean
- [x] `bun run build` — clean
- [x] `bun test` — 2448 pass / 30 skip / 0 fail

## Open questions / follow-ups (not in this PR)
1. **Per-MCP-server aggregate cap** — MCP tools key on `mcp__<server>__<tool>`, so operators can cap individual MCP tools with the same YAML (example in docs). Aggregate caps per server (`mcp__github__*` share one bucket) — defer to #8 (MCP auto-recovery).
2. **`burst = rps` default** — shipped as spec'd; classic token-bucket wisdom is `2 × rps`. Operators who want the classic pattern set `burst` explicitly. Flag if UX research shows surprise.
3. **Audit sink wiring in `up-cli.ts`** — `up` today doesn't construct a `TenantAuditSink`. `rate_limited` records only land when a caller plumbs a sink. Separate ticket: give `up` its own audit sink alongside `/metrics`.
4. **Sub-ms jitter at 1s boundary** — strict `>` comparator; `rps=1` produces ~1000ms waits that sit on the line. Configure `auditThresholdMs < 1000` to record every stall, or revisit whether `>=` is the right comparator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)