### PR TITLE
feat(cli): BUILDER_RECORD=1 capture mode (#12 stretch)

### DIFF
--- a/packages/cli/src/app.tsx
+++ b/packages/cli/src/app.tsx
@@ -23,8 +23,11 @@ import { Banner } from './banner.js';
 import {
   DEFAULT_DEPLOY_DENY_RULES,
   ProposalRegistry,
+  createRecordingProvider,
+  defaultRecordingPath,
   formatLeakWarning,
   getBuilderTools,
+  recordingEnabled,
   redactSecrets,
   renderHistory,
   renderProposal,
@@ -33,7 +36,7 @@ import {
   runHistory,
   runUndo,
 } from './builder/index.js';
-import type { Proposal, ProposalEvent } from './builder/index.js';
+import type { Proposal, ProposalEvent, RecordingProviderHandle } from './builder/index.js';
 import { BUILTIN_TOOLS } from './builtin-tools.js';
 import { expandFileRefs } from './file-refs.js';
 import { fleetGraph } from './fleet-graph-cli.js';
@@ -521,6 +524,11 @@ export function App(props: AppProps): JSX.Element {
   const [auditSink, setAuditSink] = useState<TenantAuditSink | null>(null);
 
   const engineRef = useRef<Engine | null>(null);
+  // Recording handle — set on first engine build when `BUILDER_RECORD=1`
+  // is in the environment. The same handle is reused across engine
+  // rebuilds (mode/model changes) so every turn in the session lands in
+  // the same JSONL file. `null` means recording is off.
+  const recordingRef = useRef<RecordingProviderHandle | null>(null);
   // Rebuild engine when mode changes (gate is captured by closure).
   useEffect(() => {
     const creds = resolveCredentials();
@@ -534,7 +542,30 @@ export function App(props: AppProps): JSX.Element {
     // Provider selection factored into `createProviderFromCreds` so
     // `declaragent run` and `declaragent fleet run` share the same
     // credentials → provider translation.
-    const provider: LLMProvider = createProviderFromCreds({ creds: creds ?? null });
+    let provider: LLMProvider = createProviderFromCreds({ creds: creds ?? null });
+    // BUILDER_RECORD=1 wraps the live provider so every `complete()`
+    // response lands in a JSONL file replayable by the existing
+    // fixture harness. Initialised once per session; reused on engine
+    // rebuilds (mode / model / auditSink changes) so one session =
+    // one fixture, not one-per-rebuild.
+    if (recordingEnabled(process.env)) {
+      if (recordingRef.current === null) {
+        const outputPath = process.env.BUILDER_RECORD_OUT ?? defaultRecordingPath(process.cwd());
+        recordingRef.current = createRecordingProvider({ inner: provider, outputPath });
+        append({
+          kind: 'system',
+          text: `recording conversation to ${outputPath} (BUILDER_RECORD=1)`,
+        });
+      } else {
+        // Re-wrap the *new* inner provider when the engine rebuilds.
+        // Reuse the same output path so the JSONL stays contiguous.
+        recordingRef.current = createRecordingProvider({
+          inner: provider,
+          outputPath: recordingRef.current.outputPath,
+        });
+      }
+      provider = recordingRef.current;
+    }
     // Phase-6 safety floor: deploy verbs are denied by default so a
     // model that Bash-shells `declaragent deploy ...` straight to prod
     // trips the gate rather than the live site. Users who *intend* to
@@ -665,6 +696,15 @@ export function App(props: AppProps): JSX.Element {
       return;
     }
 
+    // BUILDER_RECORD=1 — append the user turn to the fixture BEFORE
+    // file-ref expansion. Fixtures capture what the user typed, not
+    // the expanded prompt the model sees; that keeps recordings
+    // compact and human-editable. The recorder re-runs this through
+    // the secret redactor as defence in depth (the REPL's handleSubmit
+    // already redacted once, but future refactors shouldn't be able
+    // to leak a token by moving redaction around).
+    recordingRef.current?.recordUserTurn(text);
+
     // `@<path>` file-ref expansion. Rendered user line keeps the raw
     // token (that's what the user typed); the model sees the expanded
     // form with inlined file bodies.
@@ -723,6 +763,22 @@ export function App(props: AppProps): JSX.Element {
     }
   }
 
+  /**
+   * Print the BUILDER_RECORD output path (if recording is on) just
+   * before `exit()` runs. Best-effort: a broken recording must not
+   * block the REPL from closing, so we swallow any write errors.
+   */
+  function finalizeRecording(): void {
+    const handle = recordingRef.current;
+    if (handle) {
+      try {
+        process.stderr.write(`[BUILDER_RECORD] transcript saved to ${handle.outputPath}\n`);
+      } catch {
+        // stderr may already be closed during final teardown.
+      }
+    }
+  }
+
   function handleSlash(cmd: SlashCommand): void {
     switch (cmd.kind) {
       case 'help':
@@ -731,6 +787,7 @@ export function App(props: AppProps): JSX.Element {
         }
         return;
       case 'exit':
+        finalizeRecording();
         store.close();
         exit();
         return;
@@ -1240,6 +1297,7 @@ export function App(props: AppProps): JSX.Element {
       for (let p = registry.active(); p !== undefined; p = registry.active()) {
         registry.reject(p.id);
       }
+      finalizeRecording();
       store.close();
       exit();
       return;

--- a/packages/cli/src/builder/fixtures/README.md
+++ b/packages/cli/src/builder/fixtures/README.md
@@ -25,5 +25,64 @@ predetermined filesystem outcome.
 
 All five fixtures here were **hand-authored** against the published
 tool schemas; see the per-fixture Authorship note in the test file.
-When `BUILDER_RECORD=1 declaragent` lands (stretch goal in the spec),
-real Claude-driven transcripts will slot in here unchanged.
+Real Claude-driven transcripts slot in here unchanged via the
+`BUILDER_RECORD=1` capture flow below.
+
+## How to record a fixture
+
+Set `BUILDER_RECORD=1` before launching the REPL to capture every
+assistant completion and user turn into a JSONL file that's byte-for-
+byte replayable by the existing `replayFixture()` harness — no
+harness edits required.
+
+```sh
+# 1. Minimal — writes recorded-<ISO8601>.jsonl to the current directory.
+BUILDER_RECORD=1 declaragent
+
+# 2. Pick the output location explicitly.
+BUILDER_RECORD=1 \
+BUILDER_RECORD_OUT=packages/cli/src/builder/fixtures/06-my-case.jsonl \
+  declaragent
+
+# 3. Builder persona + recording in one shot.
+DECLARAGENT_BUILDER=on BUILDER_RECORD=1 declaragent
+```
+
+On the first engine build the REPL prints a `recording conversation
+to …` system line so you can confirm the capture is live. On clean
+exit (`/exit` or double-Ctrl+C) the REPL prints the output path to
+stderr so the operator can grab the transcript.
+
+Accepted truthy values for `BUILDER_RECORD`: `1`, `true`, `yes`,
+`on` (case-insensitive). Anything else — including unset — disables
+the recorder.
+
+### Safety
+
+- Every captured line passes through the same `redactSecrets()`
+  pipeline the REPL uses on user input *before* writing. Pasted
+  GitHub PATs, Slack tokens, JWTs, AWS access key ids, npm tokens,
+  `sk-…` API keys, and OAuth tokens are replaced with `<redacted:…>`
+  placeholders. Never commit a recorded fixture without eyeballing
+  the file first — the redactor catches the common cases, not every
+  possible secret shape.
+- `stream()` is not recorded. The builder's engine always uses
+  `complete()`; a future streaming path would need a matching hook
+  here before it's safe to ship.
+- Writes are durable per-line: `appendFileSync` flushes before
+  returning, so a crash mid-conversation leaves a partial but
+  replayable JSONL on disk.
+
+### Turning a recording into a checked-in fixture
+
+1. Run the capture flow end-to-end (user → assistant → apply).
+2. `mv recorded-<stamp>.jsonl packages/cli/src/builder/fixtures/NN-short-name.jsonl`.
+3. Add a comment header + any inline `#` notes explaining what
+   surface the fixture exercises.
+4. Add a test case to `__tests__/fixture-replay.test.ts` asserting
+   the expected `appliedStepKinds`.
+5. Eyeball the JSONL for anything that *looks* secret-y — the
+   redactor is tight on prefixes but not exhaustive.
+
+See `docs/ENTERPRISE_PRODUCTION_PLAN.md` §3 Item #12 and the stretch-
+goal entry for the spec the capture mode closes.

--- a/packages/cli/src/builder/index.ts
+++ b/packages/cli/src/builder/index.ts
@@ -179,3 +179,14 @@ export type { RedactResult, SecretFinding, SecretPattern } from './secret-guard.
 
 export { builderEnabled, getBuilderTools } from './register.js';
 export type { BuilderRegistrationOptions } from './register.js';
+
+export {
+  createRecordingProvider,
+  defaultRecordingPath,
+  recordingEnabled,
+} from './recording-provider.js';
+export type {
+  RecordedEntry,
+  RecordingProviderHandle,
+  RecordingProviderOptions,
+} from './recording-provider.js';

--- a/packages/cli/src/builder/recording-provider.test.ts
+++ b/packages/cli/src/builder/recording-provider.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Unit + round-trip tests for {@link createRecordingProvider}. Proves:
+ *
+ *   - `complete()` responses are appended to the JSONL output file.
+ *   - `recordUserTurn()` appends `{ role: 'user', text }` entries.
+ *   - Pasted secrets are redacted before the line lands on disk.
+ *   - The output file is replayable by the existing
+ *     {@link replayFixture} harness with zero harness-side changes —
+ *     that's the load-bearing contract for the stretch goal.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { LLMProvider, LLMRequest, LLMResponse, Message } from '@declaragent/core';
+import { replayFixture } from './__tests__/replay-harness.js';
+import {
+  type RecordedEntry,
+  createRecordingProvider,
+  defaultRecordingPath,
+  recordingEnabled,
+} from './recording-provider.js';
+
+type LLMContent = LLMResponse['content'][number];
+
+/** Minimal stub provider that replays a scripted queue of responses. */
+function stubProvider(responses: LLMResponse[]): LLMProvider {
+  let index = 0;
+  return {
+    name: 'stub',
+    async complete(_request: LLMRequest, _signal: AbortSignal): Promise<LLMResponse> {
+      const response = responses[index];
+      if (!response) throw new Error(`stub exhausted at ${index}`);
+      index += 1;
+      return response;
+    },
+    async countTokens(_messages: Message[]): Promise<number> {
+      return 0;
+    },
+  };
+}
+
+function readJsonl(path: string): RecordedEntry[] {
+  const lines = readFileSync(path, 'utf8')
+    .split('\n')
+    .filter((l) => l.trim().length > 0);
+  return lines.map((l) => JSON.parse(l) as RecordedEntry);
+}
+
+/** Mirror of the webhook-triager fixture as stub responses. */
+function webhookFleetResponses(): LLMResponse[] {
+  return [
+    {
+      stopReason: 'tool_use',
+      usage: { inputTokens: 100, outputTokens: 40 },
+      model: 'claude-opus-4-7',
+      content: [
+        { type: 'text', text: "I'll propose a webhook source plus a triage skill." },
+        {
+          type: 'tool_use',
+          id: 'call-1',
+          name: 'DeclaraProposeChange',
+          input: {
+            summary: 'webhook triager with inbound source + triage skill',
+            steps: [
+              {
+                kind: 'addSource',
+                description: 'webhook source bound to /gh',
+                payload: {
+                  type: 'webhook',
+                  id: 'gh',
+                  config: {
+                    id: 'gh',
+                    path: '/gh',
+                    target: { type: 'skill', name: 'triage' },
+                  },
+                },
+              },
+              {
+                kind: 'addSkill',
+                description: 'triage inbound events',
+                payload: {
+                  name: 'triage',
+                  description: 'triage github webhook events',
+                  body: 'When an event arrives, classify it and respond.',
+                },
+              },
+            ],
+          },
+        },
+      ] satisfies LLMContent[],
+    },
+    {
+      stopReason: 'tool_use',
+      usage: { inputTokens: 110, outputTokens: 10 },
+      model: 'claude-opus-4-7',
+      content: [
+        {
+          type: 'tool_use',
+          id: 'call-2',
+          name: 'DeclaraApplyChange',
+          input: { proposalId: '__LATEST__' },
+        },
+      ] satisfies LLMContent[],
+    },
+    {
+      stopReason: 'end_turn',
+      usage: { inputTokens: 130, outputTokens: 8 },
+      model: 'claude-opus-4-7',
+      content: [
+        { type: 'text', text: 'Done — webhook source + triage skill are in place.' },
+      ] satisfies LLMContent[],
+    },
+  ];
+}
+
+describe('recording-provider', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'declara-record-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test('passes complete() through and writes an assistant JSONL line', async () => {
+    const out = join(tmp, 'rec.jsonl');
+    const rec = createRecordingProvider({
+      inner: stubProvider([
+        {
+          stopReason: 'end_turn',
+          usage: { inputTokens: 3, outputTokens: 2 },
+          model: 'claude-opus-4-7',
+          content: [{ type: 'text', text: 'hello' }],
+        },
+      ]),
+      outputPath: out,
+    });
+    const response = await rec.complete(
+      { model: 'claude-opus-4-7', system: '', messages: [], tools: [] },
+      new AbortController().signal,
+    );
+    expect(response.content).toEqual([{ type: 'text', text: 'hello' }]);
+
+    const entries = readJsonl(out);
+    expect(entries).toHaveLength(1);
+    const entry = entries[0];
+    if (entry?.role !== 'assistant') throw new Error('expected assistant role');
+    expect(entry.content).toEqual([{ type: 'text', text: 'hello' }]);
+    expect(entry.stopReason).toBe('end_turn');
+    expect(entry.model).toBe('claude-opus-4-7');
+    expect(entry.usage).toEqual({ inputTokens: 3, outputTokens: 2 });
+  });
+
+  test('recordUserTurn appends a user entry', async () => {
+    const out = join(tmp, 'rec.jsonl');
+    const rec = createRecordingProvider({
+      inner: stubProvider([]),
+      outputPath: out,
+    });
+    rec.recordUserTurn('build me an agent');
+    const entries = readJsonl(out);
+    expect(entries).toEqual([{ role: 'user', text: 'build me an agent' }]);
+  });
+
+  test('redacts GitHub PATs from user turns before writing', () => {
+    const out = join(tmp, 'rec.jsonl');
+    const rec = createRecordingProvider({
+      inner: stubProvider([]),
+      outputPath: out,
+    });
+    // 40-char GitHub PAT pattern; matches SECRET_PATTERNS.
+    const leaked = `ghp_${'a'.repeat(40)}`;
+    rec.recordUserTurn(`use ${leaked} please`);
+    const raw = readFileSync(out, 'utf8');
+    // Never leaks the raw token.
+    expect(raw).not.toContain(leaked);
+    // Landed as the redacted placeholder instead.
+    expect(raw).toContain('<redacted:GitHub PAT>');
+  });
+
+  test('redacts secrets embedded in assistant text blocks on the write path', async () => {
+    const out = join(tmp, 'rec.jsonl');
+    const leaked = `ghp_${'b'.repeat(40)}`;
+    const rec = createRecordingProvider({
+      inner: stubProvider([
+        {
+          stopReason: 'end_turn',
+          usage: { inputTokens: 0, outputTokens: 0 },
+          model: 'claude-opus-4-7',
+          // Worst-case: the LLM quoted the token back. Shouldn't
+          // happen because redaction runs before the request is sent,
+          // but the recorder must still scrub on the write path.
+          content: [{ type: 'text', text: `saw token ${leaked}` }],
+        },
+      ]),
+      outputPath: out,
+    });
+    await rec.complete(
+      { model: 'claude-opus-4-7', system: '', messages: [], tools: [] },
+      new AbortController().signal,
+    );
+    const raw = readFileSync(out, 'utf8');
+    expect(raw).not.toContain(leaked);
+    expect(raw).toContain('<redacted:GitHub PAT>');
+  });
+
+  test('onWriteError receives errors instead of throwing from complete()', async () => {
+    // Force a write failure by pointing at a path whose parent can't
+    // be created (a file where a directory is expected).
+    const blocker = join(tmp, 'blocker');
+    writeFileSync(blocker, 'not a dir');
+    const out = join(blocker, 'sub', 'rec.jsonl');
+    const errors: Error[] = [];
+    const rec = createRecordingProvider({
+      inner: stubProvider([
+        {
+          stopReason: 'end_turn',
+          usage: { inputTokens: 0, outputTokens: 0 },
+          model: 'x',
+          content: [{ type: 'text', text: 'hi' }],
+        },
+      ]),
+      outputPath: out,
+      onWriteError: (err) => errors.push(err),
+    });
+    // Should not throw — the live session must survive a broken recorder.
+    const r = await rec.complete(
+      { model: 'x', system: '', messages: [], tools: [] },
+      new AbortController().signal,
+    );
+    expect(r.content[0]).toEqual({ type: 'text', text: 'hi' });
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  test('recordingEnabled reads BUILDER_RECORD env', () => {
+    expect(recordingEnabled({})).toBe(false);
+    expect(recordingEnabled({ BUILDER_RECORD: '0' })).toBe(false);
+    expect(recordingEnabled({ BUILDER_RECORD: 'false' })).toBe(false);
+    expect(recordingEnabled({ BUILDER_RECORD: '1' })).toBe(true);
+    expect(recordingEnabled({ BUILDER_RECORD: 'TRUE' })).toBe(true);
+    expect(recordingEnabled({ BUILDER_RECORD: 'on' })).toBe(true);
+  });
+
+  test('defaultRecordingPath is portable across filesystems', () => {
+    const now = new Date('2026-04-23T14:15:16.789Z');
+    const path = defaultRecordingPath('/tmp/fixtures', now);
+    // `:` and `.` are stripped so Windows + macOS HFS+ accept the name.
+    expect(path).not.toContain(':');
+    expect(path.endsWith('.jsonl')).toBe(true);
+    expect(path).toContain('recorded-2026-04-23T14-15-16-789Z');
+  });
+
+  test('round-trip: record with stub provider, then replay yields same step kinds', async () => {
+    // Arrange a scope root that the webhook fixture tools expect.
+    const scopeRoot = mkdtempSync(join(tmpdir(), 'declara-rt-scope-'));
+    try {
+      writeFileSync(
+        join(scopeRoot, 'agent.yaml'),
+        'name: demo\nmodel: claude-sonnet-4-5\nsystemPrompt: |\n  You are demo.\nskills: []\ntools:\n  defaults:\n    - Read\n',
+      );
+      mkdirSync(join(scopeRoot, 'skills'));
+
+      const out = join(tmp, 'round-trip.jsonl');
+      const rec = createRecordingProvider({
+        inner: stubProvider(webhookFleetResponses()),
+        outputPath: out,
+      });
+
+      // Simulate one full REPL turn: user submit + three assistant
+      // completions (text+tool_use, apply tool_use, end_turn text).
+      rec.recordUserTurn('build me an agent that triages github webhook events');
+      const sig = new AbortController().signal;
+      for (let i = 0; i < 3; i += 1) {
+        await rec.complete({ model: 'claude-opus-4-7', system: '', messages: [], tools: [] }, sig);
+      }
+
+      // Sanity: JSONL is parseable and has four entries.
+      const entries = readJsonl(out);
+      expect(entries).toHaveLength(4);
+      expect(entries[0]?.role).toBe('user');
+      expect(entries.slice(1).every((e) => e.role === 'assistant')).toBe(true);
+
+      // Replay through the existing harness with no shim. This is the
+      // load-bearing check: the recording format MUST be replayable
+      // as-is by `replayFixture`.
+      const result = await replayFixture({ fixturePath: out, scopeRoot });
+      expect(result.appliedStepKinds).toEqual(['addSource', 'addSkill']);
+      expect(result.appliedResults).toHaveLength(1);
+      expect(result.appliedResults[0]?.ok).toBe(true);
+      expect(result.turnCount).toBe(1);
+      expect(result.providerCallCount).toBe(3);
+    } finally {
+      rmSync(scopeRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/src/builder/recording-provider.ts
+++ b/packages/cli/src/builder/recording-provider.ts
@@ -1,0 +1,227 @@
+/**
+ * Recording wrapper for `LLMProvider`. Stretch-goal follow-up to
+ * Enterprise Production Plan §3 Item #12.
+ *
+ * Round-5 shipped the replay harness in `__tests__/replay-harness.ts`
+ * plus five **hand-authored** fixtures under `fixtures/*.jsonl`. This
+ * module is the inverse: wrap a live provider, pass every `complete()`
+ * call through to the inner, and append the assistant messages it
+ * emits to a JSONL file that `replayFixture()` can load without any
+ * harness-side code changes.
+ *
+ * Design contract — the written JSONL MUST be consumable by the
+ * existing replay harness. That means:
+ *   - `{ role: 'user', text }` for every REPL submit (via
+ *     {@link createRecordingProvider}'s returned `recordUserTurn`
+ *     helper — the provider itself never sees the raw user text).
+ *   - `{ role: 'assistant', content, stopReason?, usage?, model? }`
+ *     for every `complete()` response. Content is the literal
+ *     `MessageContent[]` the inner provider returned.
+ *
+ * Secret safety: whatever text reaches the LLM is whatever the REPL
+ * already redacted. The redaction pipeline runs in `app.tsx`'s
+ * `handleSubmit` BEFORE `engine.runAgent()` is called, so by the
+ * time a turn produces an assistant message the raw secret has
+ * already been replaced with `<redacted:...>` in the transcript the
+ * engine sends to the provider. The recording wrapper therefore
+ * captures the already-redacted form by construction. As a defence in
+ * depth we **also** re-run the recorded content + user turn through
+ * `redactSecrets()` on the write path — belt-and-braces against
+ * future refactors that might move redaction around.
+ *
+ * Durability: every append is an `fsync`'d, `\n`-terminated JSON line
+ * written with `appendFileSync`. No buffering inside Node. If the REPL
+ * crashes or `kill -9`s mid-conversation, the partial fixture survives
+ * intact and replayable up to the last completed assistant turn.
+ *
+ * @since 0.6.x (stretch-goal for #12)
+ */
+
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import type { LLMProvider, LLMRequest, LLMResponse, Message } from '@declaragent/core';
+import { redactSecrets } from './secret-guard.js';
+
+/**
+ * Local alias for the engine's `MessageContent` union. `@declaragent/core`
+ * re-exports a *different* `MessageContent` at the top of its surface
+ * (the channels layer's envelope shape) which collides with the
+ * messages-layer union the LLM provider actually speaks. Aliasing
+ * through `LLMResponse['content'][number]` resolves to the right
+ * one without depending on which re-export wins. Same trick the
+ * replay harness uses.
+ */
+type LLMContent = LLMResponse['content'][number];
+type StopReason = LLMResponse['stopReason'];
+
+/**
+ * A single line in the output JSONL. Shape matches the
+ * `FixtureEntry` union in `__tests__/replay-harness.ts` exactly so
+ * the recorded file is replayable without harness changes.
+ */
+export type RecordedEntry =
+  | { readonly role: 'user'; readonly text: string }
+  | {
+      readonly role: 'assistant';
+      readonly content: readonly LLMContent[];
+      readonly stopReason?: StopReason;
+      readonly usage?: { readonly inputTokens?: number; readonly outputTokens?: number };
+      readonly model?: string;
+    };
+
+export interface RecordingProviderOptions {
+  /**
+   * The live provider being wrapped. All `complete()` / `countTokens()`
+   * / `stream?()` calls pass through to this instance; the recorder
+   * only observes.
+   */
+  readonly inner: LLMProvider;
+  /**
+   * Absolute path for the JSONL output file. Parent directories are
+   * created on first write.
+   */
+  readonly outputPath: string;
+  /**
+   * Optional sink for errors during file writes. The default prints
+   * to `process.stderr` — we never throw from the recorder because a
+   * broken recording must not break the live session.
+   */
+  readonly onWriteError?: (err: Error) => void;
+}
+
+export interface RecordingProviderHandle extends LLMProvider {
+  /**
+   * Append a `{ role: 'user', text }` entry. Callers wire this into
+   * the REPL's submit path so user turns land in the JSONL in the
+   * correct order relative to the surrounding assistant messages.
+   * The text is re-redacted here as a defence in depth.
+   */
+  recordUserTurn(text: string): void;
+  /**
+   * Output path (echoed in the REPL on clean exit so the operator
+   * knows where to grab the transcript).
+   */
+  readonly outputPath: string;
+}
+
+function defaultErrorSink(err: Error): void {
+  // Intentionally not using console — logger setup varies across
+  // entry points and we'd rather land in stderr than nowhere.
+  try {
+    process.stderr.write(`[BUILDER_RECORD] write failed: ${err.message}\n`);
+  } catch {
+    // stderr may itself be closed during teardown; swallow.
+  }
+}
+
+/**
+ * Serialise one entry + newline, then `appendFileSync` it. The
+ * `appendFileSync` syscall is atomic per-line because our payloads
+ * are small (≪ `PIPE_BUF`), so a concurrent reader will never see a
+ * torn line. We don't cache a file descriptor — letting the OS open
+ * + close per append means a mid-conversation crash can't leave a
+ * stale FD holding the file's write lock on Windows.
+ */
+function appendLine(path: string, entry: RecordedEntry, onError: (err: Error) => void): void {
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    appendFileSync(path, `${JSON.stringify(entry)}\n`, 'utf8');
+  } catch (err) {
+    onError(err instanceof Error ? err : new Error(String(err)));
+  }
+}
+
+/**
+ * Run the recorded entry through the same secret-redactor that
+ * `app.tsx#handleSubmit` uses on user input. For assistant content
+ * we only redact `text` blocks — `tool_use` inputs are structured
+ * JSON that the redactor isn't designed for, and they're supposed
+ * to contain `${env:VAR}` refs (not raw secrets) by construction
+ * of the builder tools' input schemas. A tool-call payload carrying
+ * a raw token is a separate bug worth surfacing loudly; we don't
+ * silently scrub it here.
+ */
+function redactEntry(entry: RecordedEntry): RecordedEntry {
+  if (entry.role === 'user') {
+    return { role: 'user', text: redactSecrets(entry.text).redacted };
+  }
+  const rewritten: LLMContent[] = entry.content.map((block) => {
+    if (block.type !== 'text') return block;
+    return { type: 'text', text: redactSecrets(block.text).redacted };
+  });
+  return { ...entry, content: rewritten };
+}
+
+/**
+ * Wrap `inner` into a provider that records every `complete()`
+ * response to `outputPath`. `stream?()` is NOT recorded — the
+ * conversational builder's engine always uses `complete()` (it needs
+ * the full tool_use block set to drive the propose-confirm-apply
+ * loop), so exposing `stream` on the wrapper could produce silent
+ * gaps in the recording. We leave it off.
+ */
+export function createRecordingProvider(
+  options: RecordingProviderOptions,
+): RecordingProviderHandle {
+  const onError = options.onWriteError ?? defaultErrorSink;
+  const outputPath = options.outputPath;
+
+  function writeAssistant(response: LLMResponse): void {
+    const usage: { inputTokens?: number; outputTokens?: number } = {};
+    if (typeof response.usage?.inputTokens === 'number') {
+      usage.inputTokens = response.usage.inputTokens;
+    }
+    if (typeof response.usage?.outputTokens === 'number') {
+      usage.outputTokens = response.usage.outputTokens;
+    }
+    const entry: RecordedEntry = {
+      role: 'assistant',
+      content: response.content.slice(),
+      stopReason: response.stopReason,
+      ...(Object.keys(usage).length > 0 && { usage }),
+      model: response.model,
+    };
+    appendLine(outputPath, redactEntry(entry), onError);
+  }
+
+  const handle: RecordingProviderHandle = {
+    name: `recording(${options.inner.name})`,
+    outputPath,
+    async complete(request: LLMRequest, signal: AbortSignal): Promise<LLMResponse> {
+      const response = await options.inner.complete(request, signal);
+      writeAssistant(response);
+      return response;
+    },
+    async countTokens(messages: Message[]): Promise<number> {
+      return options.inner.countTokens(messages);
+    },
+    recordUserTurn(text: string): void {
+      appendLine(outputPath, redactEntry({ role: 'user', text }), onError);
+    },
+  };
+  return handle;
+}
+
+/**
+ * Compute the default output path used when `BUILDER_RECORD=1` is
+ * set without an explicit `BUILDER_RECORD_OUT`. The ISO8601 timestamp
+ * is `Z`-suffixed + `:`-stripped so filenames are portable across
+ * case-sensitive and case-insensitive filesystems (macOS HFS+ / NTFS
+ * both reject `:` in filenames).
+ */
+export function defaultRecordingPath(fixturesDir: string, now: Date = new Date()): string {
+  const stamp = now.toISOString().replace(/[:.]/g, '-');
+  return `${fixturesDir}/recorded-${stamp}.jsonl`;
+}
+
+/**
+ * True when `BUILDER_RECORD=1` (or any truthy value) is set in the
+ * current process's environment. Accepts `1`, `true`, `yes`, `on`
+ * case-insensitively — unset / `0` / `false` return false.
+ */
+export function recordingEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env.BUILDER_RECORD;
+  if (raw === undefined) return false;
+  const v = raw.trim().toLowerCase();
+  return v === '1' || v === 'true' || v === 'yes' || v === 'on';
+}


### PR DESCRIPTION
## Summary
Closes the stretch-goal follow-up for [item #12](docs/ENTERPRISE_PRODUCTION_PLAN.md). Round-5 PR #24 shipped the replay harness + 5 hand-authored fixtures; this enables PR authors to re-record fixtures from real-model transcripts when the system prompt legitimately changes.

## What landed
- `packages/cli/src/builder/recording-provider.ts` (new) — `createRecordingProvider({inner, outputPath, onWriteError?})` wraps any `LLMProvider`; passes `complete()`/`countTokens()` through; appends `{role:'assistant', content, stopReason, usage?, model}` per response. `appendFileSync` per-line — no buffering, crash-safe. `stream()` deliberately omitted (silent-gap risk). Exports `defaultRecordingPath` (Z-suffixed `:/.` stripped ISO for cross-platform filename safety) + `recordingEnabled(env)` (`1|true|yes|on`, case-insensitive).
- `packages/cli/src/builder/recording-provider.test.ts` — 8 tests (pass-through, `recordUserTurn`, GitHub-PAT redaction on both user turns and assistant text blocks, `onWriteError` error path, `recordingEnabled` env parsing, portable filename, and a round-trip: record with stub provider → `replayFixture()` → asserts `['addSource','addSkill']` step kinds land).
- `packages/cli/src/app.tsx` — when `recordingEnabled(process.env)`, wraps the configured `LLMProvider` with `createRecordingProvider` on first engine build (reused across mode/model rebuilds via `recordingRef`); `recordUserTurn` called in `runUserMessage` before file-ref expansion; `finalizeRecording` prints the output path on `/exit` and double-Ctrl+C paths.
- `packages/cli/src/builder/index.ts` — re-exports.
- `packages/cli/src/builder/fixtures/README.md` — new "How to record a fixture" section.

## Secret safety
Defence-in-depth: existing `redactSecrets()` pipeline scrubs user turns + assistant text blocks **before** writing JSONL, even though `handleSubmit` already redacts once upstream. Two dedicated redaction tests (raw `ghp_…` never appears; `<redacted:GitHub PAT>` does). `tool_use` inputs intentionally not scrubbed — they're supposed to carry `${env:VAR}` refs by construction; a raw token there is a schema bug worth surfacing loudly.

## Environment knobs
- `BUILDER_RECORD` — master switch (`1|true|yes|on`, case-insensitive).
- `BUILDER_RECORD_OUT` — override the output path. Default: `${cwd}/recorded-<ISO8601>.jsonl`.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run build` — clean
- [x] `bun test recording-provider.test.ts` — 8 pass / 0 fail (includes round-trip)
- [x] `bun test packages/cli/src/builder/` — 233 pass / 0 fail
- [x] `bun test` (full) — 2598 pass / 37 skip / 0 fail

## Follow-ups
1. `tool_result` blocks are synthesised by the engine (not the provider), so they don't land in recorded JSONL — matches the existing fixture contract (harness synthesises them on replay).
2. Usage capture granularity is `stopReason`/`inputTokens`/`outputTokens`/`model` — enough for round-trip. Cache tokens + per-block timestamps dropped; extend fixture shape + harness together if cost-regression coverage is needed.
3. Engine rebuild on `/mode`/`/model` creates a new `RecordingProviderHandle` over the same output path; `appendFileSync` serialises writes through the OS so it's safe. Longer-lived recorder with swappable inner provider ref would be cleaner but more state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)