### PR TITLE
feat(rpc): AUTH_REJECTED constant + schema-violation cardinality (#8, #9)

### DIFF
--- a/.changeset/rpc-auth-rejected-schema-violation-cardinality.md
+++ b/.changeset/rpc-auth-rejected-schema-violation-cardinality.md
@@ -1,0 +1,13 @@
+---
+'@declaragent/core': patch
+'@declaragent/plugin-agent-rpc': patch
+'@declaragent/cli': patch
+---
+
+**Security sprint follow-ups from `POST_ENTERPRISE_BACKLOG.md` — items #8 + #9.**
+
+- **#8 — `AUTH_REJECTED` promoted to `RPC_ERROR_CODES`.** Previously the envelope auth-reject path in `packages/cli/src/fleet-run.ts` stamped a bare `'AUTH_REJECTED'` string on the response envelope. The constant now lives on `@declaragent/core`'s canonical `RPC_ERROR_CODES` map alongside `AUTH_FAILED`, `VERSION_SKEW`, etc. The wire value is intentionally preserved (unprefixed `'AUTH_REJECTED'`) for back-compat with 3.0.0 receivers that pattern-match the literal — callers migrating should import `RPC_ERROR_CODES.AUTH_REJECTED` from `@declaragent/core`. Covered by `packages/core/src/rpc/errors.test.ts`.
+
+- **#9 — Capability schema-violation audit cardinality pinned per-envelope.** The emit contract on `CapabilitySchemaViolationEmitter` (in `@declaragent/plugin-agent-rpc`) + the `capability_schema_violation` audit record (in `@declaragent/core`) was already batched per envelope, but the decision was only implicit. Added explicit `POST_ENTERPRISE_BACKLOG.md #9` JSDoc + a regression test in `request-agent.test.ts` that trips 3 violations in one payload and asserts the emitter fires exactly once with all violations in the array. This caps SIEM volume under bad-actor / mass-rejection traffic — a single misconfigured envelope can trip every field in a large schema, and a per-violation emit would multiply audit rows by the schema's field count.
+
+No breaking changes. `@declaragent/cli` patch bump picks up the `RPC_ERROR_CODES.AUTH_REJECTED` wire swap in `fleet-run.ts`.

--- a/docs/POST_ENTERPRISE_BACKLOG.md
+++ b/docs/POST_ENTERPRISE_BACKLOG.md
@@ -40,8 +40,8 @@ Tick checkboxes as work lands. Group ordering = priority. Within a group, orderi
 | 5 | [ ] `rpc.auth.enabled: true` default flip + `declaragent fleet audit-rpc --suggest-enable` pre-flight inspector | Security | 1 wk | Not started | PR #25 open Q1 |
 | 6 | [ ] Per-route scope overrides on `/audit` + `/events` + `/logs` + `/status` + `/metrics` | Security | 3 d | Not started | PR #27 open Q1 |
 | 7 | [ ] `allowLoopback` + reverse-proxy semantics (X-Forwarded-For / proxy-IP-as-loopback) | Security | 2 d | Not started | PR #27 open Q2 |
-| 8 | [ ] Add `AUTH_REJECTED` to `RPC_ERROR_CODES` constant (today string literal) | Security | 30 min | Not started | PR #28 open Q3 |
-| 9 | [ ] Audit cardinality for `capability.schema_violation` — per-envelope vs per-violation | Security | 1 d | Not started | PR #23 open Q2 |
+| 8 | [x] Add `AUTH_REJECTED` to `RPC_ERROR_CODES` constant (today string literal) | Security | 30 min | Shipped — branch `agent-a/security-sprint-1-items-8-9` | `packages/core/src/rpc/errors.ts` + `errors.test.ts`; `fleet-run.ts` literals swapped for `RPC_ERROR_CODES.AUTH_REJECTED` (wire value preserved) |
+| 9 | [x] Audit cardinality for `capability.schema_violation` — per-envelope vs per-violation | Security | 1 d | Shipped — decision: batched per envelope (pinned) | `packages/plugin-agent-rpc/src/request-agent.ts` JSDoc + multi-violation regression test in `request-agent.test.ts`; inline `POST_ENTERPRISE_BACKLOG.md #9` notes in `audit/types.ts` + `fleet-run.test.ts` |
 | 10 | [ ] Schema-version policy: hard-fail vs soft-warn on breaking capability schema bumps | Security | 3 d | Not started | PR #23 open Q1 |
 | 11 | [ ] SIEM back-pressure policy (pause writes after `>1h` backlog?) | Robustness | 3 d | Not started | PR #22 open Q1 |
 | 12 | [ ] SIEM adaptive batch interval for high-volume fleets (10k tool-calls/sec) | Robustness | 3 d | Not started | PR #22 open Q2 |

--- a/packages/cli/src/fleet-run.test.ts
+++ b/packages/cli/src/fleet-run.test.ts
@@ -1228,7 +1228,10 @@ describe('fleet-run #11 typed-capability validation', () => {
         expect(events.result?.schemaSide).toBe('request');
         expect(events.result?.error?.code).toBe('EAGENTRPC_SCHEMA_VIOLATION');
 
-        // Audit row landed — one `capability_schema_violation` entry.
+        // Audit row landed — exactly one `capability_schema_violation`
+        // entry per envelope (POST_ENTERPRISE_BACKLOG.md #9: audit
+        // cardinality is batched per envelope, never per violation — so
+        // a bad-actor envelope that trips N fields still emits 1 row).
         const schemaRows = records.filter((r) => r.kind === 'capability_schema_violation');
         expect(schemaRows).toHaveLength(1);
         const first = schemaRows[0];

--- a/packages/cli/src/fleet-run.ts
+++ b/packages/cli/src/fleet-run.ts
@@ -596,7 +596,7 @@ function startAgentWorker(opts: StartAgentWorkerOptions): FleetAgentWorker {
             // Short-circuit: never dispatch to handler, but still emit
             // a best-effort failure response so sync callers don't spin.
             const error: RpcError = {
-              code: 'AUTH_REJECTED',
+              code: RPC_ERROR_CODES.AUTH_REJECTED,
               message: result.message,
             };
             try {
@@ -637,7 +637,7 @@ function startAgentWorker(opts: StartAgentWorkerOptions): FleetAgentWorker {
             }
           }
           const error: RpcError = {
-            code: 'AUTH_REJECTED',
+            code: RPC_ERROR_CODES.AUTH_REJECTED,
             message,
           };
           try {

--- a/packages/core/src/audit/types.ts
+++ b/packages/core/src/audit/types.ts
@@ -137,10 +137,11 @@ export interface RateLimitedAuditRecord {
  * — downstream consumers can drill into `violations` to enumerate which
  * paths/messages tripped.
  *
- * Cardinality decision: batched per envelope. A single `/severity: critical`
- * input rejection emits exactly one audit row even if the schema flagged
- * three different fields, because otherwise SIEM volume explodes under
- * bulk-bad-input scenarios.
+ * Cardinality decision (POST_ENTERPRISE_BACKLOG.md #9): batched per
+ * envelope. A single `/severity: critical` input rejection emits exactly
+ * one audit row even if the schema flagged three different fields,
+ * because otherwise SIEM volume explodes under bulk-bad-input scenarios.
+ * Pinned by `request-agent.test.ts` + `fleet-run.test.ts`.
  *
  * @since 1.2.0 — Enterprise Production Plan §3 Item #11
  */

--- a/packages/core/src/rpc/errors.test.ts
+++ b/packages/core/src/rpc/errors.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test';
+
+import { RPC_ERROR_CODES } from './errors.js';
+
+describe('RPC_ERROR_CODES', () => {
+  test('exposes AUTH_REJECTED as a stable wire constant (POST_ENTERPRISE_BACKLOG.md #8)', () => {
+    // Historical wire literal — must remain unprefixed for back-compat
+    // with 3.0.0 receivers that pattern-match the string. See the JSDoc
+    // on `RPC_ERROR_CODES.AUTH_REJECTED` for the rationale.
+    expect(RPC_ERROR_CODES.AUTH_REJECTED).toBe('AUTH_REJECTED');
+  });
+
+  test('every documented code is a non-empty string', () => {
+    for (const [key, value] of Object.entries(RPC_ERROR_CODES)) {
+      expect(typeof value).toBe('string');
+      expect(value.length).toBeGreaterThan(0);
+      // key should be UPPER_SNAKE_CASE
+      expect(key).toBe(key.toUpperCase());
+    }
+  });
+
+  test('codes are unique', () => {
+    const values = Object.values(RPC_ERROR_CODES);
+    expect(new Set(values).size).toBe(values.length);
+  });
+});

--- a/packages/core/src/rpc/errors.ts
+++ b/packages/core/src/rpc/errors.ts
@@ -19,6 +19,18 @@ export const RPC_ERROR_CODES = {
   TENANT_MISMATCH: 'EAGENTRPC_TENANT_MISMATCH',
   /** Caller's `x-fleet-version` is older than the receiver's `minFleetVersion`. @since 1.2.0 */
   VERSION_SKEW: 'EVERSION_SKEW',
+  /**
+   * Emitted on the response path when an inbound envelope's {@link RpcAuth}
+   * block fails verification against the registered {@link RpcAuthProvider}.
+   * Distinct from {@link AUTH_FAILED}: this one is raised by the envelope
+   * auth middleware (OIDC / OAuth2 / HMAC providers) before the capability
+   * handler runs, whereas `AUTH_FAILED` is the generic transport-layer auth
+   * error. The wire value is the historical unprefixed `AUTH_REJECTED`
+   * literal — we preserve that for back-compat with 3.0.0 receivers that
+   * pattern-match on the string. See POST_ENTERPRISE_BACKLOG.md #8.
+   * @since 1.2.1 — promoted from string literal in fleet-run.ts
+   */
+  AUTH_REJECTED: 'AUTH_REJECTED',
 } as const;
 
 export type RpcErrorCode = (typeof RPC_ERROR_CODES)[keyof typeof RPC_ERROR_CODES];

--- a/packages/plugin-agent-rpc/src/request-agent.test.ts
+++ b/packages/plugin-agent-rpc/src/request-agent.test.ts
@@ -290,6 +290,85 @@ describe('createRequestAgentTool', () => {
     expect(violations[0]).toEqual({ side: 'request', count: 1 });
   });
 
+  // POST_ENTERPRISE_BACKLOG.md #9 — audit cardinality decision.
+  //
+  // Decision: emit exactly ONE `onSchemaViolation` callback per failing
+  // envelope, carrying the full `violations[]` array — NEVER one callback
+  // per violation entry. This keeps SIEM volume bounded when a bad-actor
+  // or misconfigured caller publishes an envelope that trips every field
+  // in a large schema (without the cap, mass-rejection scenarios could
+  // multiply audit rows by the schema's field count).
+  //
+  // The `CapabilitySchemaViolationEmitter` JSDoc documents this contract;
+  // this test pins it. If you find yourself wanting to invoke the callback
+  // N times for N violations, update the JSDoc + the backlog row first.
+  test('schema-violation emits ONE callback per envelope with all violations batched (#9)', async () => {
+    const transport = stubTransport();
+    // Schema with multiple required-plus-enum fields so a single bad
+    // payload trips multiple violations at once.
+    const caps = parseCapabilitiesConfig({
+      version: 1,
+      agent: 'agent://pr-reviewer',
+      transports: [{ kind: 'memory', topics: { requests: 'agents.pr-reviewer.requests' } }],
+      capabilities: [
+        {
+          name: 'review',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              title: { type: 'string' },
+              severity: { enum: ['low', 'med', 'high'] },
+              priority: { enum: ['p0', 'p1', 'p2'] },
+            },
+            required: ['title', 'severity', 'priority'],
+          },
+        },
+      ],
+    });
+    const calls: Array<{
+      side: string;
+      violationCount: number;
+      paths: readonly string[];
+    }> = [];
+    const tool = createRequestAgentTool({
+      selfAgent: 'agent://concierge',
+      peers: singlePeer(),
+      transports: new Map([['memory', transport]]),
+      pending: createPendingRegistry(),
+      peerCapabilities: new Map([['agent://pr-reviewer', caps]]),
+      validators: createCapabilityValidatorRegistry(),
+      onSchemaViolation: ({ side, violations: v }) => {
+        calls.push({
+          side,
+          violationCount: v.length,
+          paths: v.map((entry) => entry.path),
+        });
+      },
+    });
+    const events = await collectEvents(
+      tool.execute(
+        {
+          to: 'agent://pr-reviewer',
+          capability: 'review',
+          // Bad severity, bad priority, missing title — three violations
+          // across the payload. Emitter must still fire exactly once.
+          payload: { severity: 'critical', priority: 'urgent' },
+        },
+        makeToolContext(),
+      ),
+    );
+    expect(events.result?.status).toBe('schema-violation');
+    expect(events.result?.schemaSide).toBe('request');
+    // The result carries the full violation list.
+    expect((events.result?.violations ?? []).length).toBeGreaterThanOrEqual(2);
+    // Cardinality: the emitter was invoked once per envelope, not once
+    // per violation entry — this is the load-bearing assertion.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.side).toBe('request');
+    // And the single call received every violation the validator flagged.
+    expect(calls[0]?.violationCount).toBe((events.result?.violations ?? []).length);
+  });
+
   test('valid request passes through + validates response on return', async () => {
     const transport = stubTransport();
     const pending = createPendingRegistry();

--- a/packages/plugin-agent-rpc/src/request-agent.ts
+++ b/packages/plugin-agent-rpc/src/request-agent.ts
@@ -73,9 +73,14 @@ export interface RequestAgentOutput {
  * to be wired to a {@link TenantAuditSink} so `capability_schema_violation`
  * records land on the hash chain for post-hoc debugging + SIEM export.
  *
- * Emission cardinality: one callback per envelope, carrying the full
- * violation list (not one-per-path). Keeps audit volume bounded even if
- * the payload has many bad fields.
+ * Emission cardinality (POST_ENTERPRISE_BACKLOG.md #9): exactly ONE
+ * callback per failing envelope, carrying the full violation list — NOT
+ * one callback per violation entry. This is load-bearing: under bad-actor
+ * or misconfigured-caller traffic a single envelope can trip every field
+ * in a large schema, and a per-violation emit would multiply audit volume
+ * by the field count under mass-rejection scenarios. The contract is
+ * pinned by `request-agent.test.ts` ("schema-violation emits ONE callback
+ * per envelope with all violations batched").
  *
  * @since 1.2.0 — Enterprise Production Plan §3 Item #11
  */


### PR DESCRIPTION
## Summary

Two security-sprint follow-ups from [`docs/POST_ENTERPRISE_BACKLOG.md`](../blob/main/docs/POST_ENTERPRISE_BACKLOG.md) — rows **#8** and **#9**. Both are small, scoped, no-behavior-change (where the code was already correct) or wire-preserving (where the code had a bare string literal).

### #8 — `AUTH_REJECTED` promoted to `RPC_ERROR_CODES`

`packages/cli/src/fleet-run.ts` was stamping a bare `'AUTH_REJECTED'` string on the response envelope from two call sites. The constant now lives on `@declaragent/core`'s canonical `RPC_ERROR_CODES` map alongside `AUTH_FAILED`, `VERSION_SKEW`, etc., so future callers can import and pattern-match safely.

The wire value is intentionally preserved as the unprefixed `'AUTH_REJECTED'` literal (not `'EAGENTRPC_AUTH_REJECTED'`) to stay compatible with 3.0.0 receivers already in flight. New `packages/core/src/rpc/errors.test.ts` pins that contract.

### #9 — Capability schema-violation audit cardinality: per-envelope (pinned)

Decision recorded on the JSDoc + pinned by a regression test: `onSchemaViolation` fires **exactly once per failing envelope**, carrying the full `violations[]` array. Never one-per-violation. Rationale: under bad-actor / mass-rejection traffic, a single envelope can trip every field in a large schema, and a per-violation emit would multiply audit rows by the schema's field count → SIEM volume explosion.

The implementation was already batched; this PR makes the decision explicit and tests it. New `request-agent.test.ts` case crafts a payload that trips 3 violations and asserts the emitter fires exactly once with all violations in the array.

## Files changed

- `packages/core/src/rpc/errors.ts` — add `AUTH_REJECTED` constant + JSDoc
- `packages/core/src/rpc/errors.test.ts` — new constant-presence test
- `packages/core/src/audit/types.ts` — JSDoc cross-ref to backlog #9
- `packages/plugin-agent-rpc/src/request-agent.ts` — JSDoc cardinality contract on emitter
- `packages/plugin-agent-rpc/src/request-agent.test.ts` — multi-violation regression test
- `packages/cli/src/fleet-run.ts` — `'AUTH_REJECTED'` → `RPC_ERROR_CODES.AUTH_REJECTED` (2 sites)
- `packages/cli/src/fleet-run.test.ts` — inline `#9` note on the existing cardinality assertion
- `docs/POST_ENTERPRISE_BACKLOG.md` — flip rows #8 + #9 to shipped
- `.changeset/rpc-auth-rejected-schema-violation-cardinality.md` — patch bump for core + plugin-agent-rpc + cli

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — 2640 pass / 37 skip / 0 fail across 257 files
- [x] `bun run lint` — clean (biome check 719 files)

Targeting `@declaragent/cli@0.7.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)