### PR TITLE
feat(mcp): circuit-open counter + rate-limit comparator/burst defaults + supervised recipe (#14, #28, #29, #30)

### DIFF
--- a/.changeset/robustness-sprint-1-warmups.md
+++ b/.changeset/robustness-sprint-1-warmups.md
@@ -1,0 +1,17 @@
+---
+'@declaragent/core': patch
+---
+
+**Robustness warmups for `@declaragent/cli@0.7.1` — MCP + per-tool rate limit polish.**
+
+Four small fixes bundled from the post-enterprise backlog (`docs/POST_ENTERPRISE_BACKLOG.md` rows #14, #28, #29, #30):
+
+- **#14 Dedicated `mcp_server_circuit_open_total` counter.** The labeled `mcp_server_circuit_state` gauge is kept, but alertmanager rules are much simpler against a counter — `increase(mcp_server_circuit_open_total[5m]) > 0` fires exactly once per `closed | half-open → open` transition. Registered alongside the existing MCP supervisor metrics in `packages/core/src/mcp/supervisor.ts`.
+
+- **#28 `burst = 2 × rps` default** for `createToolRateLimitGate` (per-tool rate limits, `packages/core/src/tools/rate-limit-gate.ts`). Matches classic token-bucket wisdom: one second of steady-state headroom plus one second of catch-up for transient spikes. Explicit `burst` values pass through unchanged. The provider-level limiter in `packages/core/src/providers/rate-limit.ts` is intentionally untouched.
+
+- **#29 Audit threshold comparator `>` → `>=`.** Previously `rps=1` (1000 ms wait) sat silently on the 1 s default threshold and never emitted a `rate_limited` audit record. Now it does. Zero-ms (immediate) calls still never audit.
+
+- **#30 `mcp.supervised` recipe** — new subsection in `docs-site/docs/reference/agent-yaml.mdx` showing how to use the list form to exclude a flaky server for debugging while the rest of the fleet keeps auto-recovering.
+
+No user-facing config changes beyond the defaults; no peer-dep cascade.

--- a/docs-site/docs/reference/agent-yaml.mdx
+++ b/docs-site/docs/reference/agent-yaml.mdx
@@ -271,6 +271,11 @@ mcp:
 - `mcp_server_circuit_state{server_id}` gauge (`0=closed`, `1=half-open`,
   `2=open`). A PagerDuty alert on `mcp_server_circuit_state > 1 for 5m`
   catches a genuinely stuck server.
+- `mcp_server_circuit_open_total{server_id}` counter — increments once
+  per `closed | half-open → open` transition. Prefer this over the
+  gauge for alertmanager rules: a simple
+  `increase(mcp_server_circuit_open_total[5m]) > 0` expression fires
+  exactly when a server flips to open, no label comparison required.
 
 **Behaviour.**
 - Backoff schedule: 1s, 2s, 4s, 8s, 16s, 32s, 60s cap.
@@ -280,6 +285,45 @@ mcp:
   resolves with a typed `EMCPCRASHED` error instead of hanging — the
   tool adapter translates this into a normal `ToolEvent` error so
   engine callers see a clean rejection.
+
+### Recipe — isolate a flaky MCP server for debugging
+
+When one MCP server is crash-looping and you want to understand why
+without taking the rest of the fleet offline, use the list form of
+`mcp.supervised` to *exclude* the suspect server while the healthy
+ones stay wrapped in the supervisor.
+
+```yaml
+# agent.yaml — healthy servers keep auto-recovery; `flaky-server` runs raw
+mcp:
+  servers:
+    github: { command: 'npx', args: ['@modelcontextprotocol/server-github'] }
+    jira:   { command: 'npx', args: ['@modelcontextprotocol/server-jira'] }
+    flaky-server:
+      command: 'node'
+      args: ['./mcp-servers/flaky-server.js']
+
+  # Allow-list: only these servers get supervised. `flaky-server` is
+  # absent, so it runs as a raw client — you see every crash surface as
+  # an `EMCPCRASHED` error in the engine log with no respawn churn
+  # hiding the root cause.
+  supervised: [github, jira]
+```
+
+**Why this helps.**
+- You can reproduce the crash in place. The supervisor's default 1s → 2s
+  → 4s backoff respawns the server behind your back; raw-mode leaves the
+  transport closed so the first crash is the last crash.
+- The other servers keep auto-recovering. A flaky Jira instance today
+  doesn't need to block you from investigating a flaky internal tool
+  you shipped yesterday.
+- Metrics still tell a story. The `mcp_server_restarts_total` and
+  `mcp_server_circuit_open_total` counters continue to emit for the
+  supervised servers, so your existing alerts stay useful while you
+  debug the excluded one.
+
+Once the fix lands, flip the entry back into the list (or drop to
+`supervised: all`) and redeploy — no code change required.
 
 ## `audit.export` — SIEM forwarding
 

--- a/docs/POST_ENTERPRISE_BACKLOG.md
+++ b/docs/POST_ENTERPRISE_BACKLOG.md
@@ -46,7 +46,7 @@ Tick checkboxes as work lands. Group ordering = priority. Within a group, orderi
 | 11 | [ ] SIEM back-pressure policy (pause writes after `>1h` backlog?) | Robustness | 3 d | Not started | PR #22 open Q1 |
 | 12 | [ ] SIEM adaptive batch interval for high-volume fleets (10k tool-calls/sec) | Robustness | 3 d | Not started | PR #22 open Q2 |
 | 13 | [ ] MCP graceful draining of in-flight tool calls across respawn | Robustness | 1 wk | Not started | PR #21 scope-out |
-| 14 | [ ] MCP dedicated `mcp_server_circuit_open_total` counter for alertmanager simplicity | Robustness | 1 d | Not started | PR #21 open Q3 |
+| 14 | [x] MCP dedicated `mcp_server_circuit_open_total` counter for alertmanager simplicity | Robustness | 1 d | Shipped (0.7.1) | `agent-c/robustness-sprint-1-warmups` — `packages/core/src/mcp/supervisor.ts` |
 | 15 | [ ] `/audit` tail-segment-only hash-chain verification when soak-size evidence justifies it | Robustness | 3 d | Deferred (need soak numbers) | PR #15 open Q1 |
 | 16 | [ ] Wire `TenantAuditSink` into `up-cli`'s engine path (round-5 shipped fleet-run side only) | Robustness | 1 d | Not started | PR #18 follow-up |
 | 17 | [ ] `fleet.yaml`-level `controlPlane:` block (today: process-wide listener reads per-agent; picks first + warns) | Robustness | 3 d | Not started | PR #27 open Q3 |
@@ -60,9 +60,9 @@ Tick checkboxes as work lands. Group ordering = priority. Within a group, orderi
 | 25 | [ ] NATS per-topic queue-group semantics (today one at construction-time) | Transport | 2 d | Not started | PR #13 open Q2 |
 | 26 | [ ] Kafka soak harness: literal `declaragent fleet run` subprocess spawn (today worker replicates broker loop) | Transport | 2 d | Not started | PR #10 open Q1 |
 | 27 | [ ] Per-MCP-server aggregate rate-limit cap (`mcp.rateLimit` block) | MCP | 2 d | Not started | PR #18 open Q1 |
-| 28 | [ ] `burst = rps` default revisit (classic token-bucket wisdom is `2×rps`) | MCP | 30 min | Not started | PR #18 open Q2 |
-| 29 | [ ] Audit-threshold comparator: strict `>` 1s boundary → `>=` (today `rps=1` sits silently on the line) | MCP | 30 min | Not started | PR #18 open Q4 |
-| 30 | [ ] Document `mcp.supervised: [other-healthy-server]` recipe for flaky-one-server debugging | MCP | 1 h | Not started | PR #25 open Q2 |
+| 28 | [x] `burst = rps` default revisit (classic token-bucket wisdom is `2×rps`) | MCP | 30 min | Shipped (0.7.1) | `agent-c/robustness-sprint-1-warmups` — `packages/core/src/tools/rate-limit-gate.ts` |
+| 29 | [x] Audit-threshold comparator: strict `>` 1s boundary → `>=` (today `rps=1` sits silently on the line) | MCP | 30 min | Shipped (0.7.1) | `agent-c/robustness-sprint-1-warmups` — `packages/core/src/tools/rate-limit-gate.ts` |
+| 30 | [x] Document `mcp.supervised: [other-healthy-server]` recipe for flaky-one-server debugging | MCP | 1 h | Shipped (0.7.1) | `agent-c/robustness-sprint-1-warmups` — `docs-site/docs/reference/agent-yaml.mdx` |
 | 31 | [ ] Split ServiceMonitor into optional separate file in GitOps render | GitOps | 1 d | Not started | PR #20 open Q1 |
 | 32 | [ ] Fan channel/source/plugin configs into dedicated ConfigMaps + `envFrom` mounts | GitOps | 3 d | Not started | PR #20 open Q2 |
 | 33 | [ ] Kustomize render target (Helm covers the common case today) | GitOps | 3 d | Not started | PR #20 scope-out |

--- a/packages/core/src/mcp/supervisor.test.ts
+++ b/packages/core/src/mcp/supervisor.test.ts
@@ -378,6 +378,9 @@ describe('createMCPSupervisor — crash loop → circuit opens', () => {
     const scrape = registry.scrape();
     expect(scrape).toMatch(/mcp_server_circuit_state\{[^}]*server_id="crash-loop"[^}]*\} 2/);
     expect(scrape).toContain('mcp_server_restarts_total');
+    // And the dedicated circuit-open counter incremented exactly once on
+    // the `closed → open` transition (backlog #14).
+    expect(scrape).toMatch(/mcp_server_circuit_open_total\{[^}]*server_id="crash-loop"[^}]*\} 1/);
 
     // Subsequent tool calls fail fast with a typed error.
     let threw: unknown = null;
@@ -446,6 +449,56 @@ describe('createMCPSupervisor — crash loop → circuit opens', () => {
     await flushMicrotasks(50);
     expect(sup.snapshot().state).toBe('ready');
     expect(sup.snapshot().circuit).toBe('closed');
+    await sup.stop();
+  });
+
+  test('mcp_server_circuit_open_total increments on closed → open transition (backlog #14)', async () => {
+    const clock = makeFakeClock();
+    const factory: MCPClientFactory = (lifecycle) => {
+      return makeFakeClient({
+        lifecycle,
+        failInitialize: () => new Error('init boom'),
+      });
+    };
+    const transitions: Array<{ from: string; to: string }> = [];
+    const registry = createPrometheusRegistry();
+    const sup = createMCPSupervisor({
+      serverId: 'counter-srv',
+      protocolVersion: '2024-11-05',
+      factory,
+      metrics: registry,
+      circuitThreshold: 2,
+      circuitResetMs: 24 * 3600 * 1000,
+      now: clock.now,
+      sleep: clock.sleep,
+      setTimer: clock.setTimer,
+      onCircuitTransition: (e) => {
+        transitions.push({ from: e.from, to: e.to });
+      },
+    });
+
+    // Before any transition, the counter is absent (or at 0 after
+    // registration happens on first boot failure).
+    const initialScrape = registry.scrape();
+    expect(initialScrape).not.toMatch(
+      /mcp_server_circuit_open_total\{[^}]*server_id="counter-srv"[^}]*\} [1-9]/,
+    );
+
+    void sup.start();
+    // Drive enough simulated time to exhaust backoff + open the circuit.
+    for (let i = 0; i < 6; i += 1) {
+      await clock.advance(5_000);
+      await flushMicrotasks(20);
+    }
+    expect(sup.snapshot().state).toBe('circuit-open');
+    expect(transitions.filter((t) => t.to === 'open')).toHaveLength(1);
+
+    // Counter must have incremented exactly once (label stays server-scoped).
+    const scrape = registry.scrape();
+    expect(scrape).toMatch(/mcp_server_circuit_open_total\{[^}]*server_id="counter-srv"[^}]*\} 1/);
+    // And the gauge still reflects the current state.
+    expect(scrape).toMatch(/mcp_server_circuit_state\{[^}]*server_id="counter-srv"[^}]*\} 2/);
+
     await sup.stop();
   });
 });

--- a/packages/core/src/mcp/supervisor.ts
+++ b/packages/core/src/mcp/supervisor.ts
@@ -23,11 +23,18 @@
  * sleep, and asks the factory for a fresh one. On success it re-issues
  * `initialize` + `listTools` and notifies the caller.
  *
- * Metrics: two Prometheus series, registered through the shared
+ * Metrics: three Prometheus series, registered through the shared
  * {@link MetricsRegistry}:
  *
  *   - `mcp_server_restarts_total{server_id, reason}`  counter
  *   - `mcp_server_circuit_state{server_id}`           gauge (0/1/2)
+ *   - `mcp_server_circuit_open_total{server_id}`      counter
+ *
+ * The `circuit_open_total` counter is a dedicated companion to the
+ * labeled `circuit_state` gauge: alertmanager rules stay simple
+ * (`increase(mcp_server_circuit_open_total[5m]) > 0`) without having
+ * to compare a gauge against a constant label value. It increments
+ * exactly once per `closed|half-open → open` transition.
  *
  * @since 0.7.0
  */
@@ -271,6 +278,15 @@ export function createMCPSupervisor(opts: CreateMCPSupervisorOptions): MCPSuperv
         inc() {},
         dec() {},
       };
+  // Dedicated counter for circuit-open transitions. Alertmanager rules
+  // are much simpler with a counter (`increase(...[5m]) > 0`) than a
+  // gauge-plus-label comparison — see Post-Enterprise Backlog #14.
+  const circuitOpenCounter: Counter = opts.metrics
+    ? opts.metrics.counter(
+        'mcp_server_circuit_open_total',
+        'Count of MCP supervisor circuit-open transitions per server.',
+      )
+    : { inc() {} };
 
   const serverLabels: Readonly<Record<string, string>> = { server_id: opts.serverId };
 
@@ -320,6 +336,9 @@ export function createMCPSupervisor(opts: CreateMCPSupervisorOptions): MCPSuperv
 
   circuit.onTransition(({ from, to }) => {
     circuitGauge.set(CIRCUIT_GAUGE_VALUE[to], serverLabels);
+    if (to === 'open') {
+      circuitOpenCounter.inc(1, serverLabels);
+    }
     logger.warn('mcp.supervisor.circuit.transition', {
       serverId: opts.serverId,
       from,

--- a/packages/core/src/tools/rate-limit-gate.test.ts
+++ b/packages/core/src/tools/rate-limit-gate.test.ts
@@ -111,11 +111,11 @@ describe('ToolRateLimitGate', () => {
     expect(sleep.waits).toEqual([waited]);
   });
 
-  test('acceptance #1: Bash capped at 1rps, 10 calls take ≥ 9s (deterministic clock)', async () => {
+  test('acceptance #1: Bash capped at 1rps, 10 calls take ≥ 8s (deterministic clock)', async () => {
     const clock = makeFakeClock();
     const sleep = makeFakeSleep(clock);
     const gate = createToolRateLimitGate({
-      limits: { Bash: { rps: 1 } }, // burst defaults to rps (=1)
+      limits: { Bash: { rps: 1 } }, // burst defaults to 2 × rps (=2)
       now: clock.now,
       sleep: sleep.sleep,
     });
@@ -126,13 +126,13 @@ describe('ToolRateLimitGate', () => {
     }
     const elapsedMs = clock.now() - start;
 
-    // First call consumes the burst; each of the remaining 9 waits
-    // ~1000 ms. Expected total ≈ 9000 ms.
-    expect(elapsedMs).toBeGreaterThanOrEqual(9_000);
-    expect(sleep.waits).toHaveLength(9);
+    // First 2 calls consume the burst; each of the remaining 8 waits
+    // ~1000 ms. Expected total ≈ 8000 ms.
+    expect(elapsedMs).toBeGreaterThanOrEqual(8_000);
+    expect(sleep.waits).toHaveLength(8);
   });
 
-  test('acceptance #1 (wall-clock variant): real timers, 1rps × 10 takes ≥ 9s', async () => {
+  test('acceptance #1 (wall-clock variant): real timers, 1rps × 10 takes ≥ 8s', async () => {
     const gate = createToolRateLimitGate({
       limits: { Bash: { rps: 1 } },
     });
@@ -143,9 +143,9 @@ describe('ToolRateLimitGate', () => {
     }
     const elapsedMs = performance.now() - started;
 
-    // Token bucket: 1 burst + 9 refill waits at ~1000 ms each.
-    // Allow a tiny floor of 8900 ms to absorb setTimeout slop on CI.
-    expect(elapsedMs).toBeGreaterThanOrEqual(8_900);
+    // Token bucket: 2 burst + 8 refill waits at ~1000 ms each.
+    // Allow a tiny floor of 7900 ms to absorb setTimeout slop on CI.
+    expect(elapsedMs).toBeGreaterThanOrEqual(7_900);
   }, 15_000);
 
   test('audit record fires only when wait > auditThresholdMs (default 1s)', async () => {
@@ -257,7 +257,7 @@ describe('ToolRateLimitGate', () => {
     );
   });
 
-  test('burst defaults to rps when omitted', async () => {
+  test('burst defaults to 2 × rps when omitted (classic token-bucket wisdom)', async () => {
     const clock = makeFakeClock();
     const sleep = makeFakeSleep(clock);
     const gate = createToolRateLimitGate({
@@ -265,10 +265,38 @@ describe('ToolRateLimitGate', () => {
       now: clock.now,
       sleep: sleep.sleep,
     });
-    // Without explicit burst, bucket should absorb 3 immediate calls.
-    for (let i = 0; i < 3; i += 1) {
+    // Without explicit burst, bucket should absorb 2 × 3 = 6 immediate calls.
+    for (let i = 0; i < 6; i += 1) {
       expect(await gate.acquire('Bash', { tenantId: 't1' })).toBe(0);
     }
     expect(sleep.waits).toHaveLength(0);
+    // The 7th call must wait (burst is exhausted).
+    const waited = await gate.acquire('Bash', { tenantId: 't1' });
+    expect(waited).toBeGreaterThan(0);
+  });
+
+  test('rps=1 sits exactly on the 1s audit threshold and still records (Item #29: `>=` boundary)', async () => {
+    const clock = makeFakeClock();
+    const sleep = makeFakeSleep(clock);
+    const { sink, recorded } = makeRecordingSink();
+    // rps=1, burst=1 → second call waits exactly 1000 ms, which under
+    // the previous strict `>` comparator sat silently on the boundary.
+    // With `>=` we now record it.
+    const gate = createToolRateLimitGate({
+      limits: { Bash: { rps: 1, burst: 1 } },
+      auditSink: sink,
+      now: clock.now,
+      sleep: sleep.sleep,
+    });
+
+    await gate.acquire('Bash', { tenantId: 't1' }); // burst → 0 ms wait
+    expect(recorded).toHaveLength(0);
+
+    await gate.acquire('Bash', { tenantId: 't1' }); // waits exactly 1000 ms
+    expect(recorded).toHaveLength(1);
+    const rec = recorded[0] as RateLimitedAuditRecord;
+    expect(rec.kind).toBe('rate_limited');
+    expect(rec.tool).toBe('Bash');
+    expect(rec.waitMs).toBe(1_000);
   });
 });

--- a/packages/core/src/tools/rate-limit-gate.ts
+++ b/packages/core/src/tools/rate-limit-gate.ts
@@ -32,8 +32,9 @@ export interface ToolRateLimitConfig {
   rps: number;
   /**
    * Max calls the bucket can absorb without throttling. Defaults to
-   * `rps` (i.e. a full second of steady-state calls). Operators who
-   * want the classic "2× rps" burst behaviour set it explicitly.
+   * `2 × rps` — classic token-bucket wisdom: a full second of headroom
+   * plus one second of catch-up for transient spikes. Operators who
+   * want a tighter ceiling (e.g. `burst == rps`) set it explicitly.
    */
   burst?: number;
 }
@@ -113,7 +114,7 @@ export function createToolRateLimitGate(options: ToolRateLimitGateOptions): Tool
     if (!(cfg.rps > 0)) {
       throw new Error(`tools.rateLimit[${toolName}]: rps must be > 0 (got ${String(cfg.rps)})`);
     }
-    const burst = Math.max(1, cfg.burst ?? cfg.rps);
+    const burst = Math.max(1, cfg.burst ?? Math.ceil(cfg.rps * 2));
     const bucketOpts: ConstructorParameters<typeof ProviderTokenBucket>[0] = {
       ratePerSec: cfg.rps,
       burst,
@@ -135,7 +136,7 @@ export function createToolRateLimitGate(options: ToolRateLimitGateOptions): Tool
         // Metrics hook misbehaved; the tool call already waited. Swallow.
       }
     }
-    if (waitMs > auditThresholdMs && auditSink) {
+    if (waitMs >= auditThresholdMs && auditSink && waitMs > 0) {
       const cfg = configs.get(toolName);
       if (cfg) {
         const record: RateLimitedAuditRecord & { tenantId: string } = {


### PR DESCRIPTION
## Summary

Bundles four post-enterprise backlog warmups targeting `@declaragent/cli@0.7.1` — backlog rows [#14](../blob/main/docs/POST_ENTERPRISE_BACKLOG.md), [#28](../blob/main/docs/POST_ENTERPRISE_BACKLOG.md), [#29](../blob/main/docs/POST_ENTERPRISE_BACKLOG.md), [#30](../blob/main/docs/POST_ENTERPRISE_BACKLOG.md).

- **#14 Dedicated `mcp_server_circuit_open_total` counter** (Robustness, 1d). Supervisor registers and increments a bare counter on every `closed | half-open → open` transition so alertmanager rules can collapse to `increase(mcp_server_circuit_open_total[5m]) > 0`. The labeled `mcp_server_circuit_state` gauge is preserved for dashboards.
- **#28 `burst = 2 × rps` default** (MCP, 30min). `createToolRateLimitGate` now follows classic token-bucket wisdom. Explicit `burst` values pass through unchanged. The provider-level limiter in `packages/core/src/providers/rate-limit.ts` is intentionally untouched.
- **#29 Audit comparator `>` → `>=`** (MCP, 30min). Previously `rps=1` (1000 ms wait) sat silently on the 1 s default threshold and never emitted a `rate_limited` audit record. Now it does. Zero-ms immediate calls still never audit.
- **#30 `mcp.supervised` recipe** (MCP, 1h). New Recipe subsection in `docs-site/docs/reference/agent-yaml.mdx` showing the list form used to isolate a flaky server for debugging while the rest of the fleet keeps auto-recovering. Also documents the new counter alongside the existing gauge.

## Files changed

- `packages/core/src/mcp/supervisor.ts` — register + increment `mcp_server_circuit_open_total` counter.
- `packages/core/src/mcp/supervisor.test.ts` — assertions on `crash loop → circuit opens` + dedicated counter test.
- `packages/core/src/tools/rate-limit-gate.ts` — `burst ?? Math.ceil(rps * 2)`; audit comparator `>=` with a `waitMs > 0` guard.
- `packages/core/src/tools/rate-limit-gate.test.ts` — update existing `rps=1, 10 calls ≥ 9s` assertions to reflect the new 2-token burst (10 calls ≥ 8s), new `rps=1` boundary test for #29, rewritten `burst defaults to 2 × rps` test.
- `docs-site/docs/reference/agent-yaml.mdx` — extended `mcp.supervised` observability list with the new counter + new Recipe subsection.
- `docs/POST_ENTERPRISE_BACKLOG.md` — check off rows #14, #28, #29, #30.
- `.changeset/robustness-sprint-1-warmups.md` — `@declaragent/core` patch.

## Test plan

- [x] `bun run typecheck` — green
- [x] `bun test` — 2638 pass / 37 skip / 0 fail (+2 new tests)
- [x] `bun run lint` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)