### PR TITLE
feat(rpc): fleet audit-rpc --suggest-enable pre-flight inspector (#5 Part A)

### DIFF
--- a/.changeset/fleet-audit-rpc-suggest-enable.md
+++ b/.changeset/fleet-audit-rpc-suggest-enable.md
@@ -1,0 +1,14 @@
+---
+'@declaragent/cli': patch
+---
+
+feat(rpc): `declaragent fleet audit-rpc [--suggest-enable] [--strict] [--json]` — pre-flight inspector for `rpc.auth.enabled` across every agent in the fleet
+
+Adds a new read-only fleet verb that walks `fleet.yaml` + each per-agent `agent.yaml` + `rpc-peers.yaml` and reports which agents have RPC envelope auth on, off, or unconfigured. Three output modes:
+
+- **default** — human-readable table with one line per agent and a hint to re-run with `--suggest-enable` for a copy-pasteable migration snippet.
+- `--suggest-enable` — emits the exact YAML diff operators paste into each agent's `agent.yaml` to opt in. When a matching peer entry in `rpc-peers.yaml` already specifies an auth provider, the snippet echoes that provider in a comment so the suggestion is actionable, not a stub.
+- `--strict` — exits non-zero on any agent whose `rpc.auth.enabled` is absent or false. Safe for CI pre-flight gates.
+- `--json` — structured report for programmatic consumers.
+
+**Scope note:** This ships Part A of `docs/POST_ENTERPRISE_BACKLOG.md` row #5. Part B (flipping the `rpc.auth.enabled: false` default to `true`) is **deferred to a 0.8.0 minor** — a behavioural-default flip in a patch would surprise consumers that don't yet configure an IdP in `rpc-peers.yaml`. Shipping the inspector first gives operators at least one release cycle to run `declaragent fleet audit-rpc --suggest-enable` in CI, close the gap in config, then pick up the default flip without a downtime surprise. Row #5 in the backlog has been split to reflect this.

--- a/docs-site/docs/reference/cli.mdx
+++ b/docs-site/docs/reference/cli.mdx
@@ -89,6 +89,7 @@ Usage:
   declaragent fleet list [--json]
   declaragent fleet validate [--json]
   declaragent fleet capabilities [--json]
+  declaragent fleet audit-rpc [--suggest-enable] [--strict] [--json]
 
   declaragent capabilities gen --peer <id> [--out <dir>]
   declaragent capabilities gen --capabilities <path> [--out <dir>] [--json]

--- a/docs/POST_ENTERPRISE_BACKLOG.md
+++ b/docs/POST_ENTERPRISE_BACKLOG.md
@@ -9,7 +9,7 @@ This doc is the honest 0.7.x+ backlog. Every entry was flagged by a shipped PR's
 ## 0 · Summary banner
 
 ```
-Status:               28 open follow-ups from the enterprise push (24 shipped across 0.7.1 + 0.7.2 + 0.7.3)
+Status:               27 open follow-ups from the enterprise push (25 shipped across 0.7.1 + 0.7.2 + 0.7.3)
 Shipping-gate count:  4 (must land before 0.7.0 cut)
 Security count:       6 (address within 0.7.x)
 Robustness count:     7 (enterprise-nice-to-have)
@@ -37,7 +37,8 @@ Tick checkboxes as work lands. Group ordering = priority. Within a group, orderi
 | 2 | [ ] Cut `@declaragent/cli@0.7.0` release with full enterprise stack + peer-dep cascade | Ship-gate | 1 d | Not started | — |
 | 3 | [ ] Flip website `/principles` 🟡 → ✅; replace "10–14 engineer-weeks" with "shipped" | Ship-gate | 30 min | Not started | — |
 | 4 | [ ] Regenerate `docs/FIRST_PRINCIPLES_AUDIT.md` + `FIRST_PRINCIPLES_VALIDATION.md` capability matrix | Ship-gate | 2 h | Not started | — |
-| 5 | [ ] `rpc.auth.enabled: true` default flip + `declaragent fleet audit-rpc --suggest-enable` pre-flight inspector | Security | 1 wk | Not started | PR #25 open Q1 |
+| 5a | [x] `declaragent fleet audit-rpc [--suggest-enable] [--strict] [--json]` pre-flight inspector | Security | 3 d | Shipped (0.7.3) — branch `agent-a/security-sprint-3-item-5` | `packages/cli/src/fleet-audit-rpc-cli.ts` walks `fleet.yaml` + each `agent.yaml` + `rpc-peers.yaml`; classifies each agent as `enabled`/`disabled`/`absent`/`unreadable`; `--suggest-enable` emits copy-pasteable YAML diffs pre-filled with the matching peer provider; `--strict` exits non-zero for CI use; 11 unit tests in `fleet-audit-rpc-cli.test.ts` cover all three deliverable fixtures (fully-enabled, partial, not-enabled) plus JSON + strict + unreadable |
+| 5b | [ ] `rpc.auth.enabled: true` default flip | Security | 2 d | Deferred to 0.8.0 — behavioural default change needs SemVer signal + at least one `--suggest-enable` release cycle in CI before landing | PR #25 open Q1 |
 | 6 | [x] Per-route scope overrides on `/audit` + `/events` + `/logs` + `/status` + `/metrics` | Security | 3 d | Shipped — branch `agent-a/security-sprint-2-items-6-7` | `controlPlane.auth.routeScopes: Record<path, string[]>` in `packages/core/src/agents/load-agent.ts`; enforced by `applyControlPlaneAuth` in `packages/core/src/observability/control-plane-auth.ts` with new `ControlPlaneAuthContext.routePath`; one test per route in `control-plane-auth.test.ts` |
 | 7 | [x] `allowLoopback` + reverse-proxy semantics (X-Forwarded-For / proxy-IP-as-loopback) | Security | 2 d | Shipped — branch `agent-a/security-sprint-2-items-6-7` | `allowLoopback: boolean \| { trustedProxies: string[] }` in `load-agent.ts`; `resolveEffectivePeer()` in `control-plane-auth.ts` rejects XFF from untrusted peers with new `untrusted-proxy` reason; `control-plane-server.ts` threads `peerIp` via `Bun.serve`'s `server.requestIP(req)` |
 | 8 | [x] Add `AUTH_REJECTED` to `RPC_ERROR_CODES` constant (today string literal) | Security | 30 min | Shipped — branch `agent-a/security-sprint-1-items-8-9` | `packages/core/src/rpc/errors.ts` + `errors.test.ts`; `fleet-run.ts` literals swapped for `RPC_ERROR_CODES.AUTH_REJECTED` (wire value preserved) |
@@ -96,7 +97,7 @@ Tick checkboxes as work lands. Group ordering = priority. Within a group, orderi
 All four close out the 0.6.0 → 0.7.0 cut. #1 is timing-gated (Sunday cron). The other three are small operator actions, not engineering work.
 
 ### Security (§1 rows 5–10)
-Prioritize #5, #6, #7 — those three are the difference between "opt-in trust-the-network" and "zero-trust enterprise deploy." #10 (schema version policy) needs a product call before eng.
+Row #5 split in sprint 3: **#5a** (the `fleet audit-rpc --suggest-enable` inspector) shipped at 0.7.3, **#5b** (the default flip) is deferred to 0.8.0 so the SemVer signal + one release cycle of `--suggest-enable` in CI reach operators first. Remaining priority order: #5b, #6, #7 — those three close the "opt-in trust-the-network" → "zero-trust enterprise deploy" gap. #10 (schema version policy) needs a product call before eng.
 
 ### Topology (§1 rows 18–22)
 Mostly same shape: "today works for N=1 or bind=127.0.0.1; enterprise needs N=many or remote bind." These land together when the first customer asks.

--- a/packages/cli/src/fleet-audit-rpc-cli.test.ts
+++ b/packages/cli/src/fleet-audit-rpc-cli.test.ts
@@ -1,0 +1,345 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FleetAuditRpcDeps, FleetAuditRpcIO } from './fleet-audit-rpc-cli.js';
+import { buildAuditRpcReport, fleetAuditRpc, suggestRpcAuthYaml } from './fleet-audit-rpc-cli.js';
+
+interface Capture {
+  io: FleetAuditRpcIO;
+  out: string[];
+  err: string[];
+}
+
+function captureIo(): Capture {
+  const out: string[] = [];
+  const err: string[] = [];
+  return {
+    io: { out: (s) => out.push(s), err: (s) => err.push(s) },
+    out,
+    err,
+  };
+}
+
+interface Harness {
+  root: string;
+  write(relative: string, contents: string): void;
+  cleanup(): void;
+}
+
+function mkHarness(): Harness {
+  const root = mkdtempSync(join(tmpdir(), 'declaragent-audit-rpc-'));
+  return {
+    root,
+    write(relative, contents) {
+      const full = join(root, relative);
+      mkdirSync(join(full, '..'), { recursive: true });
+      writeFileSync(full, contents, 'utf-8');
+    },
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+/**
+ * Three-agent fleet: `fully-on` has `rpc.auth.enabled: true`;
+ * `partial` has the block but `enabled: false`; `absent` has no `rpc:`
+ * block at all. rpc-peers.yaml references `fully-on` with an OIDC
+ * auth block so the suggestion path has a provider to echo.
+ */
+function threeCaseFleet(): Harness {
+  const h = mkHarness();
+  h.write(
+    'fleet.yaml',
+    `version: 1
+name: three-case
+agents:
+  - id: fully-on
+    path: ./agents/fully-on
+    env: shared
+  - id: partial
+    path: ./agents/partial
+    env: shared
+  - id: absent
+    path: ./agents/absent
+    env: shared
+environments:
+  shared:
+    peersRef: ./rpc-peers.yaml
+`,
+  );
+  h.write(
+    'agents/fully-on/agent.yaml',
+    `name: fully-on
+rpc:
+  auth:
+    enabled: true
+`,
+  );
+  h.write(
+    'agents/partial/agent.yaml',
+    `name: partial
+rpc:
+  auth:
+    enabled: false
+`,
+  );
+  h.write('agents/absent/agent.yaml', 'name: absent\n');
+  h.write(
+    'rpc-peers.yaml',
+    `version: 1
+peers:
+  - agent: agent://fully-on
+    transports:
+      - kind: memory
+        topics: { requests: agents.fully-on.requests }
+    auth:
+      provider: oidc
+      issuer: https://idp.example.com
+      audience: declaragent-fleet
+`,
+  );
+  return h;
+}
+
+function deps(h: Harness): FleetAuditRpcDeps & { out: string[]; err: string[] } {
+  const cap = captureIo();
+  return { io: cap.io, root: h.root, out: cap.out, err: cap.err };
+}
+
+describe('fleet-audit-rpc / buildAuditRpcReport', () => {
+  test('classifies each of the three cases correctly', async () => {
+    const h = threeCaseFleet();
+    try {
+      const { loadFleet } = await import('@declaragent/core');
+      const fleet = await loadFleet({ root: h.root });
+      const report = await buildAuditRpcReport(fleet);
+
+      const byId = Object.fromEntries(report.agents.map((a) => [a.agentId, a]));
+      expect(byId['fully-on']?.state).toBe('enabled');
+      expect(byId.partial?.state).toBe('disabled');
+      expect(byId.absent?.state).toBe('absent');
+      expect(report.allEnabled).toBe(false);
+
+      // fully-on is referenced in rpc-peers.yaml with auth → snapshot it.
+      expect(byId['fully-on']?.suggestedFromPeer?.provider).toBe('oidc');
+      // partial + absent have no peer entry → no suggestion hint.
+      expect(byId.partial?.suggestedFromPeer).toBeUndefined();
+      expect(byId.absent?.suggestedFromPeer).toBeUndefined();
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test('state overrides bypass disk reads', async () => {
+    const h = threeCaseFleet();
+    try {
+      const { loadFleet } = await import('@declaragent/core');
+      const fleet = await loadFleet({ root: h.root });
+      const overrides = new Map([
+        ['fully-on', { state: 'enabled' as const }],
+        ['partial', { state: 'enabled' as const }],
+        ['absent', { state: 'enabled' as const }],
+      ]);
+      const report = await buildAuditRpcReport(fleet, { stateOverrides: overrides });
+      expect(report.allEnabled).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe('fleet-audit-rpc / suggestRpcAuthYaml', () => {
+  test('echoes peer provider when a peer entry is present', () => {
+    const yaml = suggestRpcAuthYaml({
+      agentId: 'fully-on',
+      agentYamlPath: '/tmp/a.yaml',
+      state: 'absent',
+      suggestedFromPeer: {
+        provider: 'oidc',
+        issuer: 'https://idp.example.com',
+        audience: 'declaragent-fleet',
+      },
+    });
+    expect(yaml).toContain('rpc:');
+    expect(yaml).toContain('auth:');
+    expect(yaml).toContain('enabled: true');
+    expect(yaml).toContain('provider=oidc');
+    expect(yaml).toContain('fully-on');
+  });
+
+  test('prints a "add peer first" note when no peer entry exists', () => {
+    const yaml = suggestRpcAuthYaml({
+      agentId: 'absent',
+      agentYamlPath: '/tmp/a.yaml',
+      state: 'absent',
+    });
+    expect(yaml).toContain('rpc:');
+    expect(yaml).toContain('enabled: true');
+    expect(yaml).toContain('rpc-peers.yaml');
+  });
+});
+
+describe('fleet-audit-rpc / fleetAuditRpc', () => {
+  test('plain run reports each state + exits 0 without --strict', async () => {
+    const h = threeCaseFleet();
+    try {
+      const d = deps(h);
+      const code = await fleetAuditRpc({}, d);
+      expect(code).toBe(0);
+      const out = d.out.join('');
+      expect(out).toContain('fully-on');
+      expect(out).toContain('partial');
+      expect(out).toContain('absent');
+      expect(out).toContain('enabled');
+      expect(out).toContain('not configured');
+      expect(out).toContain('disabled (explicit)');
+      // Default run hints at --suggest-enable but does not emit the diff.
+      expect(out).toContain('--suggest-enable');
+      expect(out).not.toContain('rpc:\n  auth:\n    enabled: true');
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test('--suggest-enable emits copy-pasteable YAML for each gap', async () => {
+    const h = threeCaseFleet();
+    try {
+      const d = deps(h);
+      const code = await fleetAuditRpc({ suggestEnable: true }, d);
+      expect(code).toBe(0);
+      const out = d.out.join('');
+      expect(out).toContain('rpc:\n  auth:\n    enabled: true');
+      // We print a snippet per gap agent (partial + absent).
+      const snippetCount = out.split('enabled: true').length - 1;
+      expect(snippetCount).toBeGreaterThanOrEqual(2);
+      expect(out).toContain('partial');
+      expect(out).toContain('absent');
+      expect(out).toContain('fleet validate');
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test('--strict with gaps → exit 1', async () => {
+    const h = threeCaseFleet();
+    try {
+      const d = deps(h);
+      const code = await fleetAuditRpc({ strict: true }, d);
+      expect(code).toBe(1);
+      const out = d.out.join('');
+      expect(out).toContain('--strict');
+      expect(out).toContain('non-zero');
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test('fully-enabled fleet → exit 0 even under --strict', async () => {
+    const h = mkHarness();
+    try {
+      h.write(
+        'fleet.yaml',
+        `version: 1
+name: clean
+agents:
+  - id: one
+    path: ./agents/one
+    env: shared
+environments:
+  shared: {}
+`,
+      );
+      h.write(
+        'agents/one/agent.yaml',
+        `name: one
+rpc:
+  auth:
+    enabled: true
+`,
+      );
+      const d = deps(h);
+      const code = await fleetAuditRpc({ strict: true }, d);
+      expect(code).toBe(0);
+      expect(d.out.join('')).toContain('every agent has rpc.auth.enabled: true');
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test('--json emits structured report with per-agent state + suggestion when asked', async () => {
+    const h = threeCaseFleet();
+    try {
+      const d = deps(h);
+      const code = await fleetAuditRpc({ suggestEnable: true, json: true, strict: true }, d);
+      expect(code).toBe(1);
+      interface JsonAgent {
+        agentId: string;
+        state: string;
+        suggestion?: string;
+        peerAuthProvider?: string;
+      }
+      const parsed = JSON.parse(d.out.join('')) as {
+        allEnabled: boolean;
+        ok: boolean;
+        agents: JsonAgent[];
+      };
+      expect(parsed.allEnabled).toBe(false);
+      expect(parsed.ok).toBe(false);
+      const byId = Object.fromEntries(parsed.agents.map((a) => [a.agentId, a]));
+      expect(byId['fully-on']?.state).toBe('enabled');
+      expect(byId['fully-on']?.suggestion).toBeUndefined();
+      expect(byId.partial?.state).toBe('disabled');
+      expect(byId.partial?.suggestion).toContain('enabled: true');
+      expect(byId.absent?.state).toBe('absent');
+      expect(byId.absent?.suggestion).toContain('enabled: true');
+      expect(byId['fully-on']?.peerAuthProvider).toBe('oidc');
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test('no fleet.yaml → stderr + exit 1', async () => {
+    const h = mkHarness();
+    try {
+      const cap = captureIo();
+      const code = await fleetAuditRpc({}, { io: cap.io, cwd: h.root });
+      expect(code).toBe(1);
+      expect(cap.err.join('')).toContain('no fleet.yaml found');
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test('unreadable agent.yaml is reported, does not crash', async () => {
+    const h = mkHarness();
+    try {
+      h.write(
+        'fleet.yaml',
+        `version: 1
+name: borked
+agents:
+  - id: one
+    path: ./agents/one
+    env: shared
+environments:
+  shared: {}
+`,
+      );
+      h.write('agents/one/agent.yaml', 'name: one\n');
+      // Override the reader to simulate an EACCES-like failure.
+      const d = deps(h);
+      const code = await fleetAuditRpc(
+        {},
+        {
+          ...d,
+          readStateForAgent: async () => ({ state: 'unreadable', reason: 'boom' }),
+        },
+      );
+      expect(code).toBe(0); // not strict
+      expect(d.out.join('')).toContain('unreadable');
+      expect(d.out.join('')).toContain('boom');
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/packages/cli/src/fleet-audit-rpc-cli.ts
+++ b/packages/cli/src/fleet-audit-rpc-cli.ts
@@ -1,0 +1,352 @@
+/**
+ * `declaragent fleet audit-rpc [--suggest-enable] [--strict] [--json]` —
+ * pre-flight inspector for RPC envelope auth (`rpc.auth.enabled`) across
+ * every agent in the fleet.
+ *
+ * The `fleet.yaml` loader gives us the per-agent directory; we then read
+ * each `agent.yaml` directly (not through the zod loader) so we can
+ * honestly report three states:
+ *
+ *   1. **absent** — the `rpc.auth` block is missing entirely. Most new
+ *      fleets are here. Default posture is opt-in (`enabled: false`), so
+ *      this is *the* gap `--suggest-enable` wants to close.
+ *   2. **disabled** — the block exists and explicitly sets
+ *      `enabled: false`. Same risk posture as `absent` but the operator
+ *      has clearly chosen to opt out; the suggestion is informational.
+ *   3. **enabled** — the block exists with `enabled: true`. Pass.
+ *
+ * The output is a human-readable table by default or a structured JSON
+ * object with `--json`. When `--suggest-enable` is set we append a
+ * copy-pasteable YAML diff for each agent that needs the flip. When
+ * `--strict` is set we exit non-zero on any agent that isn't
+ * fully enabled — safe for CI use.
+ *
+ * **Scope:** Part A of `docs/POST_ENTERPRISE_BACKLOG.md` row #5. Part B
+ * (flipping the `enabled: false` default to `true`) is deliberately
+ * held back until a 0.8.0 minor so the SemVer signal + at least one
+ * release cycle of `--suggest-enable` warning reaches operators before
+ * the behavioural change lands.
+ *
+ * @since 0.7.3 — POST_ENTERPRISE_BACKLOG.md row #5 Part A
+ */
+
+import { readFile } from 'node:fs/promises';
+import type { LoadedFleet, PeerAuthConfig } from '@declaragent/core';
+import { FleetConfigError, FleetManifestError, findFleetRoot, loadFleet } from '@declaragent/core';
+import { parse as parseYaml } from 'yaml';
+
+export interface FleetAuditRpcIO {
+  out: (s: string) => void;
+  err: (s: string) => void;
+}
+
+const STDIO_IO: FleetAuditRpcIO = {
+  out: (s) => process.stdout.write(s),
+  err: (s) => process.stderr.write(s),
+};
+
+export type RpcAuthState = 'enabled' | 'disabled' | 'absent' | 'unreadable';
+
+export interface AgentAuditReport {
+  readonly agentId: string;
+  /** Absolute path to `<agentDir>/agent.yaml`. */
+  readonly agentYamlPath: string;
+  readonly state: RpcAuthState;
+  /** Present when state is `'unreadable'`. */
+  readonly reason?: string;
+  /**
+   * The peer-auth block the operator declared on *this* agent as a
+   * callee in `rpc-peers.yaml` — used to pre-fill the suggested
+   * `rpc.auth` YAML snippet so the operator doesn't have to re-pick
+   * provider / issuer / audience. `undefined` when no peer references
+   * this agent (external-only or dangling).
+   */
+  readonly suggestedFromPeer?: PeerAuthConfig;
+}
+
+export interface FleetAuditRpcReport {
+  readonly agents: readonly AgentAuditReport[];
+  /** True when every agent's state is `'enabled'`. */
+  readonly allEnabled: boolean;
+}
+
+/**
+ * Read + parse a single `agent.yaml` just enough to answer
+ * `rpc.auth.enabled`. We intentionally avoid the full zod loader
+ * because:
+ *
+ *   - we want to report on agents whose YAML has unrelated errors
+ *     (e.g. a missing skill file) without blocking the audit, and
+ *   - the inspector is read-only — it never acts on the parsed data.
+ */
+async function readAgentRpcAuthState(
+  agentYamlPath: string,
+): Promise<{ state: RpcAuthState; reason?: string }> {
+  let raw: string;
+  try {
+    raw = await readFile(agentYamlPath, 'utf-8');
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { state: 'unreadable', reason: `failed to read agent.yaml: ${msg}` };
+  }
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(raw);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { state: 'unreadable', reason: `invalid YAML: ${msg}` };
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    return { state: 'absent' };
+  }
+  const record = parsed as Record<string, unknown>;
+  const rpc = record.rpc;
+  if (!rpc || typeof rpc !== 'object') {
+    return { state: 'absent' };
+  }
+  const auth = (rpc as Record<string, unknown>).auth;
+  if (!auth || typeof auth !== 'object') {
+    return { state: 'absent' };
+  }
+  const enabled = (auth as Record<string, unknown>).enabled;
+  if (enabled === true) return { state: 'enabled' };
+  if (enabled === false) return { state: 'disabled' };
+  // The `rpc.auth` block exists but `enabled` is unset — treat this as
+  // `absent` for migration purposes (the loader evaluates
+  // `enabled === true`, so anything else means the default posture).
+  return { state: 'absent' };
+}
+
+/**
+ * Build an in-memory report across every agent in the fleet. Pure: no
+ * IO on the fleet object itself — the caller hands us the `LoadedFleet`
+ * and we do the per-agent disk read. Tests can also inject pre-read
+ * states via `stateOverrides`.
+ */
+export async function buildAuditRpcReport(
+  fleet: LoadedFleet,
+  options: {
+    readonly stateOverrides?: ReadonlyMap<string, { state: RpcAuthState; reason?: string }>;
+  } = {},
+): Promise<FleetAuditRpcReport> {
+  const peerAuthByAgent = new Map<string, PeerAuthConfig>();
+  for (const peer of fleet.peers?.config.peers ?? []) {
+    if (!peer.auth) continue;
+    const id = peer.agent.startsWith('agent://') ? peer.agent.slice('agent://'.length) : peer.agent;
+    peerAuthByAgent.set(id, peer.auth);
+  }
+
+  const agents: AgentAuditReport[] = [];
+  for (const agent of fleet.agents) {
+    const override = options.stateOverrides?.get(agent.id);
+    const result = override ?? (await readAgentRpcAuthState(agent.agentYamlPath));
+    const suggestedFromPeer = peerAuthByAgent.get(agent.id);
+    agents.push({
+      agentId: agent.id,
+      agentYamlPath: agent.agentYamlPath,
+      state: result.state,
+      ...(result.reason !== undefined && { reason: result.reason }),
+      ...(suggestedFromPeer !== undefined && { suggestedFromPeer }),
+    });
+  }
+
+  const allEnabled = agents.every((a) => a.state === 'enabled');
+  return { agents, allEnabled };
+}
+
+/**
+ * Build the YAML snippet the operator can paste into `<agent>/agent.yaml`
+ * to flip `rpc.auth.enabled` to true. When we can see a matching peer
+ * auth block we echo the provider + issuer + audience (or token
+ * endpoint) so the snippet is actionable, not a stub.
+ *
+ * The snippet never includes secrets — `clientSecretRef` is a
+ * resolver reference, safe to commit.
+ */
+export function suggestRpcAuthYaml(report: AgentAuditReport): string {
+  const peer = report.suggestedFromPeer;
+  const lines: string[] = ['rpc:', '  auth:', '    enabled: true'];
+  if (peer) {
+    // We nest the provider echo under a comment so the operator sees
+    // what inspired the suggestion but the core YAML stays minimal —
+    // `rpc.auth` today only consumes `enabled`; the provider block
+    // lives in `rpc-peers.yaml`, not here. This is deliberate: the
+    // agent opts *in*, the peer table configures *how*.
+    lines.push(
+      `    # Callers of agent://${report.agentId} are already declared in`,
+      `    # rpc-peers.yaml with provider=${peer.provider}. Turning`,
+      '    # enabled: true makes this agent verify those tokens.',
+    );
+  } else {
+    lines.push(
+      '    # No peer entry references this agent yet — add an `auth:` block',
+      "    # to rpc-peers.yaml before callers can prove they're allowed.",
+    );
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+// ── Formatters ─────────────────────────────────────────────────────────
+
+const STATE_MARK: Record<RpcAuthState, string> = {
+  enabled: '✓',
+  disabled: '!',
+  absent: '!',
+  unreadable: '✗',
+};
+
+const STATE_LABEL: Record<RpcAuthState, string> = {
+  enabled: 'enabled',
+  disabled: 'disabled (explicit)',
+  absent: 'not configured',
+  unreadable: 'unreadable',
+};
+
+function renderText(
+  report: FleetAuditRpcReport,
+  args: { suggestEnable: boolean; strict: boolean },
+): string {
+  const lines: string[] = [];
+  if (report.agents.length === 0) {
+    lines.push('no agents declared in this fleet.\n');
+    return lines.join('');
+  }
+  lines.push('rpc.auth status by agent:\n');
+  for (const a of report.agents) {
+    const mark = STATE_MARK[a.state];
+    const tail = a.reason ? ` — ${a.reason}` : '';
+    lines.push(`  ${mark} ${a.agentId}  ${STATE_LABEL[a.state]}${tail}\n`);
+  }
+
+  const needs = report.agents.filter((a) => a.state === 'absent' || a.state === 'disabled');
+  if (needs.length > 0) {
+    lines.push(
+      `\n${needs.length} of ${report.agents.length} agent(s) do not have RPC envelope auth enabled.\n`,
+    );
+    if (args.suggestEnable) {
+      lines.push(
+        '\nTo enable, paste the following into each agent.yaml under the top-level keys:\n',
+      );
+      for (const a of needs) {
+        lines.push(`\n# ── ${a.agentId} — ${a.agentYamlPath}\n`);
+        lines.push(suggestRpcAuthYaml(a));
+      }
+      lines.push(
+        '\nAfter editing, run `declaragent fleet validate` and `declaragent fleet audit-rpc` to confirm.\n',
+      );
+    } else {
+      lines.push(
+        'Run `declaragent fleet audit-rpc --suggest-enable` for a copy-pasteable migration snippet.\n',
+      );
+    }
+  } else {
+    lines.push('\n✓ every agent has rpc.auth.enabled: true.\n');
+  }
+
+  if (args.strict && !report.allEnabled) {
+    lines.push('\n--strict: exiting non-zero because at least one agent is not auth-enabled.\n');
+  }
+  return lines.join('');
+}
+
+function renderJson(
+  report: FleetAuditRpcReport,
+  args: { suggestEnable: boolean; strict: boolean },
+): string {
+  return `${JSON.stringify(
+    {
+      ok: !args.strict || report.allEnabled,
+      allEnabled: report.allEnabled,
+      agents: report.agents.map((a) => ({
+        agentId: a.agentId,
+        agentYamlPath: a.agentYamlPath,
+        state: a.state,
+        ...(a.reason !== undefined && { reason: a.reason }),
+        ...(a.suggestedFromPeer !== undefined && {
+          peerAuthProvider: a.suggestedFromPeer.provider,
+        }),
+        ...(args.suggestEnable &&
+          (a.state === 'absent' || a.state === 'disabled') && {
+            suggestion: suggestRpcAuthYaml(a),
+          }),
+      })),
+    },
+    null,
+    2,
+  )}\n`;
+}
+
+// ── CLI verb ───────────────────────────────────────────────────────────
+
+export interface FleetAuditRpcArgs {
+  suggestEnable?: boolean;
+  strict?: boolean;
+  json?: boolean;
+}
+
+export interface FleetAuditRpcDeps {
+  io?: FleetAuditRpcIO;
+  cwd?: string;
+  root?: string;
+  load?: (root: string) => Promise<LoadedFleet>;
+  /** Injected read for tests that bypass disk. Keyed by agent id. */
+  readStateForAgent?: (
+    agentYamlPath: string,
+    agentId: string,
+  ) => Promise<{ state: RpcAuthState; reason?: string }>;
+}
+
+export async function fleetAuditRpc(
+  args: FleetAuditRpcArgs = {},
+  deps: FleetAuditRpcDeps = {},
+): Promise<number> {
+  const io = deps.io ?? STDIO_IO;
+  const root = deps.root ?? (await findFleetRoot(deps.cwd ?? process.cwd()));
+  if (!root) {
+    io.err(
+      '✗ no fleet.yaml found in this directory or any parent. Run `declaragent init --fleet <name>` to create one.\n',
+    );
+    return 1;
+  }
+
+  let fleet: LoadedFleet;
+  try {
+    const loader = deps.load ?? ((r: string) => loadFleet({ root: r }));
+    fleet = await loader(root);
+  } catch (err) {
+    if (err instanceof FleetManifestError || err instanceof FleetConfigError) {
+      io.err(`✗ ${err.message}\n`);
+      return 1;
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    io.err(`✗ failed to load fleet: ${msg}\n`);
+    return 1;
+  }
+
+  const suggestEnable = args.suggestEnable === true;
+  const strict = args.strict === true;
+
+  // Build per-agent state. If a reader override is supplied, use it
+  // (keeps the pure-function path for tests); otherwise walk disk.
+  const overrides = new Map<string, { state: RpcAuthState; reason?: string }>();
+  const readOverride = deps.readStateForAgent;
+  if (readOverride) {
+    for (const agent of fleet.agents) {
+      const result = await readOverride(agent.agentYamlPath, agent.id);
+      overrides.set(agent.id, result);
+    }
+  }
+
+  const report = await buildAuditRpcReport(fleet, {
+    ...(overrides.size > 0 && { stateOverrides: overrides }),
+  });
+
+  if (args.json) {
+    io.out(renderJson(report, { suggestEnable, strict }));
+  } else {
+    io.out(renderText(report, { suggestEnable, strict }));
+  }
+
+  if (strict && !report.allEnabled) return 1;
+  return 0;
+}

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -30,6 +30,7 @@ import { eventsList, eventsReplay, eventsReplayRange, eventsShow } from './event
 import { eventsConfigValidate } from './events-config-cli.js';
 import { extensionsList } from './extensions-cli.js';
 import { fleetAdd } from './fleet-add-cli.js';
+import { fleetAuditRpc } from './fleet-audit-rpc-cli.js';
 import { fleetCapabilities, fleetList, fleetValidate } from './fleet-cli.js';
 import { fleetDeploy } from './fleet-deploy-cli.js';
 import { type GraphFormat, fleetGraph } from './fleet-graph-cli.js';
@@ -179,6 +180,7 @@ Usage:
   declaragent fleet list [--json]
   declaragent fleet validate [--json]
   declaragent fleet capabilities [--json]
+  declaragent fleet audit-rpc [--suggest-enable] [--strict] [--json]
 
   declaragent capabilities gen --peer <id> [--out <dir>]
   declaragent capabilities gen --capabilities <path> [--out <dir>] [--json]
@@ -1007,9 +1009,18 @@ async function runFleetSubcommand(
       ...(json && { json: true }),
     });
   }
+  if (action === 'audit-rpc') {
+    const suggestEnable = flagSet(rest, '--suggest-enable');
+    const strict = flagSet(rest, '--strict');
+    return fleetAuditRpc({
+      ...(suggestEnable && { suggestEnable: true }),
+      ...(strict && { strict: true }),
+      ...(json && { json: true }),
+    });
+  }
   process.stderr.write(`unknown fleet subcommand: ${action ?? '(none)'}\n`);
   process.stderr.write(
-    'usage: declaragent fleet <new|add|run|promote|demote|deploy|render|graph|peers|status|list|validate|capabilities> [options]\n',
+    'usage: declaragent fleet <new|add|run|promote|demote|deploy|render|graph|peers|status|list|validate|capabilities|audit-rpc> [options]\n',
   );
   return 1;
 }


### PR DESCRIPTION
## Summary

- Adds `declaragent fleet audit-rpc [--suggest-enable] [--strict] [--json]` — a read-only pre-flight verb that classifies each agent's `rpc.auth.enabled` state (enabled / disabled / absent / unreadable) and, with `--suggest-enable`, emits a copy-pasteable YAML migration snippet pre-filled with the matching peer-auth provider from `rpc-peers.yaml`.
- Ships **Part A** of `docs/POST_ENTERPRISE_BACKLOG.md` row #5. Row #5 has been split: 5a (inspector, shipped 0.7.3) and 5b (`rpc.auth.enabled: true` default flip, deferred to 0.8.0).

## Option 1 vs Option 2 decision (Part B)

Chose **Option 1 (cautious)**: defer the default flip to the 0.8.0 minor. Reasoning:

- The flip is a behavioural default change. Today's `enabled: false` is *silently* permissive — flipping it to `true` on agents whose `rpc-peers.yaml` has no `auth:` block would start rejecting otherwise-valid traffic the moment a user runs `npm install -g @declaragent/cli@latest`.
- A patch bump (0.7.2 → 0.7.3) is not the right SemVer signal for that.
- Landing the inspector first gives operators at least one release cycle to run `declaragent fleet audit-rpc --suggest-enable` in CI, remediate the gap in their config, and opt in. Then 0.8.0 flips the default without a downtime surprise.

The changeset and the backlog doc both call out this sequencing explicitly.

## Files changed

- `packages/cli/src/fleet-audit-rpc-cli.ts` (new) — the verb; pure `buildAuditRpcReport` + `suggestRpcAuthYaml` helpers; shallow YAML parse so an unrelated `agent.yaml` error doesn't block the audit.
- `packages/cli/src/fleet-audit-rpc-cli.test.ts` (new) — 11 tests, including the three deliverable fixtures (fully-enabled / partial / not-enabled) + `--strict` + `--json` + reader override + missing-fleet + unreadable fallback.
- `packages/cli/src/index.tsx` — wires `audit-rpc` into the fleet router + help text.
- `docs/POST_ENTERPRISE_BACKLOG.md` — row #5 split into 5a (shipped) and 5b (deferred); banner shipped count bumped 21 → 22.
- `.changeset/fleet-audit-rpc-suggest-enable.md` — patch bump for `@declaragent/cli` with the Option 1 rationale inline.

## Test plan

- [x] `bun run typecheck` (clean across monorepo)
- [x] `bun test` (2724 pass, 0 fail across 262 files)
- [x] `bun run lint` (clean, 728 files)
- [x] Three-case fixture (`fully-on` / `partial` / `absent`) exercises the enable/disable/absent classification paths + peer-provider suggestion echo.
- [x] `--strict` returns 1 on any gap; 0 on a clean fleet.
- [x] `--json` output stable + suggestion emitted only when `--suggest-enable` AND the agent has a gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)