### PR TITLE
feat(siem): back-pressure pause + adaptive batch interval (#11, #12)

### DIFF
--- a/.changeset/siem-backpressure-adaptive-batch.md
+++ b/.changeset/siem-backpressure-adaptive-batch.md
@@ -1,0 +1,15 @@
+---
+'@declaragent/core': patch
+---
+
+feat(siem): back-pressure pause after backlog threshold + adaptive batch interval
+
+- New `BackpressureController` (`createBackpressureController`) coordinates a pause on NEW audit writes when the SIEM export backlog (oldest unshipped row age) exceeds a configurable threshold (default 1 h). `createSqliteAuditSink` accepts the controller via a new `backpressure` option; `sink.record()` consults it before every write.
+- Two policies — `fail-fast` (default; throws `AuditBackpressureError` so callers surface the outage) and `drop` (silently counts drops via Prometheus). The fail-fast default preserves the hash-chain invariant; `drop` is opt-in for callers that would rather shed load than back-pressure a hot path.
+- `startAuditExportLoop` gains a `backpressure: { enabled, pauseAfterBacklogMs, evaluateIntervalMs, controller }` option. A separate timer evaluates the threshold (default every 30 s) via the new `TenantAuditSink.oldestUnshippedMs` method. Pause engages above threshold, resumes automatically once the queue drains back under.
+- New metrics: `declaragent.audit.backpressure.paused_total`, `declaragent.audit.backpressure.active`, `declaragent.audit.backpressure.drops_total`, `declaragent.audit.backpressure.backlog_ms`.
+- `startAuditExportLoop` gains a `batch: { minIntervalMs, maxIntervalMs, targetBatchRows }` option that turns the fixed tick cadence into a simple proportional controller. Bursts (batch hits `batchSize` cap) halve the interval toward `minIntervalMs`; idle queues relax toward `maxIntervalMs`; steady state where shipped ≈ target stays put. Solves the "10k tool-calls/sec produces 100k-row batches that OOM the shipper" problem called out in POST_ENTERPRISE_BACKLOG.md #12.
+- New metrics: `declaragent.audit.batch.interval_ms` gauge + `declaragent.audit.batch.rows` histogram (geometric buckets up to 50k).
+- Both features are opt-in; omitting the new options preserves pre-0.7.4 behaviour (unbounded intake, fixed 10 s cadence).
+
+Backlog: POST_ENTERPRISE_BACKLOG.md #11, #12.

--- a/docs/POST_ENTERPRISE_BACKLOG.md
+++ b/docs/POST_ENTERPRISE_BACKLOG.md
@@ -9,7 +9,7 @@ This doc is the honest 0.7.x+ backlog. Every entry was flagged by a shipped PR's
 ## 0 · Summary banner
 
 ```
-Status:               23 open follow-ups from the enterprise push (29 shipped across 0.7.1 + 0.7.2 + 0.7.3 + 0.7.4)
+Status:               21 open follow-ups from the enterprise push (31 shipped across 0.7.1 + 0.7.2 + 0.7.3 + 0.7.4)
 Shipping-gate count:  4 (must land before 0.7.0 cut)
 Security count:       6 (address within 0.7.x)
 Robustness count:     7 (enterprise-nice-to-have)
@@ -44,8 +44,8 @@ Tick checkboxes as work lands. Group ordering = priority. Within a group, orderi
 | 8 | [x] Add `AUTH_REJECTED` to `RPC_ERROR_CODES` constant (today string literal) | Security | 30 min | Shipped — branch `agent-a/security-sprint-1-items-8-9` | `packages/core/src/rpc/errors.ts` + `errors.test.ts`; `fleet-run.ts` literals swapped for `RPC_ERROR_CODES.AUTH_REJECTED` (wire value preserved) |
 | 9 | [x] Audit cardinality for `capability.schema_violation` — per-envelope vs per-violation | Security | 1 d | Shipped — decision: batched per envelope (pinned) | `packages/plugin-agent-rpc/src/request-agent.ts` JSDoc + multi-violation regression test in `request-agent.test.ts`; inline `POST_ENTERPRISE_BACKLOG.md #9` notes in `audit/types.ts` + `fleet-run.test.ts` |
 | 10 | [ ] Schema-version policy: hard-fail vs soft-warn on breaking capability schema bumps | Security | 3 d | Not started | PR #23 open Q1 |
-| 11 | [ ] SIEM back-pressure policy (pause writes after `>1h` backlog?) | Robustness | 3 d | Not started | PR #22 open Q1 |
-| 12 | [ ] SIEM adaptive batch interval for high-volume fleets (10k tool-calls/sec) | Robustness | 3 d | Not started | PR #22 open Q2 |
+| 11 | [x] SIEM back-pressure policy (pause writes after `>1h` backlog?) | Robustness | 3 d | Shipped (0.7.4) — branch `agent-c/siem-sprint-4-items-11-12` | `packages/core/src/audit/backpressure.ts` introduces `BackpressureController` + `AuditBackpressureError` (fail-fast default; `drop` policy opt-in w/ counter); `createSqliteAuditSink({ backpressure })` gates `record()` before every write; `startAuditExportLoop({ backpressure: { enabled, pauseAfterBacklogMs, evaluateIntervalMs, controller } })` evaluates `sink.oldestUnshippedMs()` on a 30 s timer (configurable) — pauses above 1 h default, auto-resumes when queue drains under threshold. New metrics: `audit.backpressure.paused_total`, `audit.backpressure.active`, `audit.backpressure.drops_total`, `audit.backpressure.backlog_ms`. 9 tests in `backpressure.test.ts`. |
+| 12 | [x] SIEM adaptive batch interval for high-volume fleets (10k tool-calls/sec) | Robustness | 3 d | Shipped (0.7.4) — branch `agent-c/siem-sprint-4-items-11-12` | `startAuditExportLoop({ batch: { minIntervalMs, maxIntervalMs, targetBatchRows } })` replaces fixed cadence with a proportional controller: batch hitting `batchSize` cap halves the interval toward `minIntervalMs` (default 200 ms), idle queues double toward `maxIntervalMs` (default 10 s), steady-state stays put. New metrics: `audit.batch.interval_ms` gauge + `audit.batch.rows` histogram. Opt-in via `batch` option — omitting preserves pre-0.7.4 fixed behaviour. 6 tests in `adaptive-batch.test.ts`. |
 | 13 | [ ] MCP graceful draining of in-flight tool calls across respawn | Robustness | 1 wk | Not started | PR #21 scope-out |
 | 14 | [x] MCP dedicated `mcp_server_circuit_open_total` counter for alertmanager simplicity | Robustness | 1 d | Shipped (0.7.1) | `agent-c/robustness-sprint-1-warmups` — `packages/core/src/mcp/supervisor.ts` |
 | 15 | [ ] `/audit` tail-segment-only hash-chain verification when soak-size evidence justifies it | Robustness | 3 d | Deferred (need soak numbers) | PR #15 open Q1 |

--- a/packages/core/src/audit/adaptive-batch.test.ts
+++ b/packages/core/src/audit/adaptive-batch.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tests for the adaptive batch-interval controller on the SIEM export
+ * loop (POST_ENTERPRISE_BACKLOG.md #12).
+ *
+ * The controller is a simple proportional adjuster: next interval
+ * shrinks on big batches (queue is deeper than target) and relaxes on
+ * small / empty batches (queue is shallower than target).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { createPrometheusRegistry } from '../observability/prometheus.js';
+import { startAuditExportLoop } from './exporter-loop.js';
+import type { AuditExporter, PushResult } from './exporters/exporter.js';
+import { createSqliteAuditSink } from './sqlite-sink.js';
+import type { TenantAuditRecord, TenantAuditSink } from './types.js';
+
+function makeFakeExporter(): AuditExporter {
+  const push: AuditExporter['push'] = async (batch): Promise<PushResult> => ({
+    ok: true,
+    acked: batch.length,
+  });
+  return { name: 'splunk:adaptive', vendor: 'splunk', push };
+}
+
+async function seed(sink: TenantAuditSink, count: number): Promise<void> {
+  for (let i = 1; i <= count; i += 1) {
+    const rec: TenantAuditRecord = {
+      kind: 'tool_call',
+      ts: 1_700_000_000_000 + i,
+      tenantId: 'acme',
+      sessionId: `s${i}`,
+      tool: 'Bash',
+      permissionKey: 'bash:exec',
+      outcome: 'allow',
+    };
+    await sink.record(rec);
+  }
+}
+
+describe('startAuditExportLoop — adaptive batch interval', () => {
+  let sink: TenantAuditSink;
+  beforeEach(async () => {
+    sink = await createSqliteAuditSink({ path: ':memory:' });
+  });
+  afterEach(async () => {
+    await sink.close();
+  });
+
+  it('contracts toward minIntervalMs on sustained burst', async () => {
+    // Seed way more than batchSize so every tick hits the cap.
+    await seed(sink, 10_000);
+    const loop = startAuditExportLoop({
+      sink,
+      exporter: makeFakeExporter(),
+      intervalMs: 10_000, // start wide
+      batchSize: 500,
+      batch: {
+        minIntervalMs: 200,
+        maxIntervalMs: 10_000,
+        targetBatchRows: 500,
+      },
+    });
+
+    const initial = loop.currentIntervalMs();
+    // Each tick maxes out (shipped === batchSize) so the controller
+    // halves the interval every iteration.
+    for (let i = 0; i < 10; i += 1) {
+      await loop.flushNow();
+    }
+    const after = loop.currentIntervalMs();
+    expect(after).toBeLessThan(initial);
+    expect(after).toBe(200); // clamped at min after enough halving
+    await loop.stop();
+  });
+
+  it('relaxes toward maxIntervalMs on empty queue', async () => {
+    // No rows seeded → every tick ships 0 → interval doubles.
+    const loop = startAuditExportLoop({
+      sink,
+      exporter: makeFakeExporter(),
+      intervalMs: 500, // start below max
+      batchSize: 500,
+      batch: {
+        minIntervalMs: 200,
+        maxIntervalMs: 10_000,
+        targetBatchRows: 500,
+      },
+    });
+    const initial = loop.currentIntervalMs();
+    for (let i = 0; i < 10; i += 1) {
+      await loop.flushNow();
+    }
+    const after = loop.currentIntervalMs();
+    expect(after).toBeGreaterThanOrEqual(initial);
+    expect(after).toBe(10_000);
+    await loop.stop();
+  });
+
+  it('stays stable at steady state when shipped ≈ target', async () => {
+    // Seed exactly the target per tick and refill between ticks.
+    await seed(sink, 500);
+    const loop = startAuditExportLoop({
+      sink,
+      exporter: makeFakeExporter(),
+      intervalMs: 5_000,
+      batchSize: 500,
+      batch: {
+        minIntervalMs: 200,
+        maxIntervalMs: 10_000,
+        targetBatchRows: 500,
+      },
+    });
+    const initial = loop.currentIntervalMs();
+    // The first tick ships `batchSize` rows which trips the cap logic
+    // (halves the interval). So seed in a way that the sink returns
+    // exactly targetBatchRows without hitting the cap — use a smaller
+    // batchSize than target? No — target IS capped by batchSize. Instead
+    // this test validates that when shipped < batchSize and == target,
+    // the ratio == 1 so the interval is unchanged.
+    // With batchSize=500 and 500 rows waiting, the query returns 500
+    // which equals batchSize → hits cap path. So raise batchSize above
+    // target:
+    await loop.stop();
+    const loop2 = startAuditExportLoop({
+      sink,
+      exporter: makeFakeExporter(),
+      intervalMs: 5_000,
+      batchSize: 1_000,
+      batch: { minIntervalMs: 200, maxIntervalMs: 10_000, targetBatchRows: 500 },
+    });
+    // Seed a fresh sink scope: wipe by using initial == post-seed of 500 rows,
+    // the first tick ships 500 rows (target) → ratio 1 → interval unchanged.
+    const before = loop2.currentIntervalMs();
+    expect(await loop2.flushNow()).toBe(500);
+    const after = loop2.currentIntervalMs();
+    expect(after).toBe(before);
+    expect(initial).toBe(5_000);
+    await loop2.stop();
+  });
+
+  it('exposes interval + batch-rows via Prometheus metrics', async () => {
+    await seed(sink, 50);
+    const registry = createPrometheusRegistry();
+    const loop = startAuditExportLoop({
+      sink,
+      exporter: makeFakeExporter(),
+      intervalMs: 1_000,
+      batchSize: 500,
+      metrics: registry,
+      batch: { minIntervalMs: 200, maxIntervalMs: 10_000, targetBatchRows: 500 },
+    });
+    await loop.flushNow();
+    const scrape = registry.scrape();
+    expect(scrape).toContain('declaragent_audit_batch_interval_ms');
+    expect(scrape).toContain('declaragent_audit_batch_rows');
+    // Histogram has buckets + count + sum lines.
+    expect(scrape).toMatch(/declaragent_audit_batch_rows_bucket\{[^}]*le="\+Inf"[^}]*\} \d/);
+    await loop.stop();
+  });
+
+  it('omits adaptive logic when `batch` is undefined (back-compat)', async () => {
+    await seed(sink, 10);
+    const loop = startAuditExportLoop({
+      sink,
+      exporter: makeFakeExporter(),
+      intervalMs: 7_777,
+      batchSize: 500,
+    });
+    expect(loop.currentIntervalMs()).toBe(7_777);
+    await loop.flushNow();
+    // Still the fixed interval; no adjustment happens.
+    expect(loop.currentIntervalMs()).toBe(7_777);
+    await loop.stop();
+  });
+
+  it('clamps a supplied intervalMs outside [min, max] into the window', async () => {
+    await seed(sink, 1);
+    const loop = startAuditExportLoop({
+      sink,
+      exporter: makeFakeExporter(),
+      intervalMs: 500_000, // absurdly large
+      batchSize: 500,
+      batch: { minIntervalMs: 200, maxIntervalMs: 10_000, targetBatchRows: 500 },
+    });
+    // Clamped at construction time to maxIntervalMs.
+    expect(loop.currentIntervalMs()).toBe(10_000);
+    await loop.stop();
+  });
+});

--- a/packages/core/src/audit/backpressure.test.ts
+++ b/packages/core/src/audit/backpressure.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Tests for the SIEM back-pressure controller + sink integration + loop
+ * evaluator (POST_ENTERPRISE_BACKLOG.md #11).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { createPrometheusRegistry } from '../observability/prometheus.js';
+import { AuditBackpressureError, createBackpressureController } from './backpressure.js';
+import { startAuditExportLoop } from './exporter-loop.js';
+import type { AuditExporter, PushResult } from './exporters/exporter.js';
+import { createSqliteAuditSink } from './sqlite-sink.js';
+import type { TenantAuditRecord, TenantAuditSink } from './types.js';
+
+// ── Fake exporter ──────────────────────────────────────────────────────────
+
+interface FakeExporter extends AuditExporter {
+  setBehavior(b: (batch: readonly unknown[]) => Promise<PushResult>): void;
+  callCount(): number;
+}
+
+function makeFakeExporter(name = 'splunk:bp-test'): FakeExporter {
+  let behavior: (batch: readonly unknown[]) => Promise<PushResult> = async (b) => ({
+    ok: true,
+    acked: b.length,
+  });
+  let calls = 0;
+  const push: AuditExporter['push'] = async (batch) => {
+    calls += 1;
+    return behavior(batch);
+  };
+  return {
+    name,
+    vendor: 'splunk',
+    push,
+    setBehavior: (b) => {
+      behavior = b;
+    },
+    callCount: () => calls,
+  };
+}
+
+async function seed(sink: TenantAuditSink, count: number, firstTs: number): Promise<void> {
+  for (let i = 0; i < count; i += 1) {
+    const rec: TenantAuditRecord = {
+      kind: 'tool_call',
+      ts: firstTs + i,
+      tenantId: 'acme',
+      sessionId: `s${i}`,
+      tool: 'Bash',
+      permissionKey: 'bash:exec',
+      outcome: 'allow',
+    };
+    await sink.record(rec);
+  }
+}
+
+// ── Controller unit tests ──────────────────────────────────────────────────
+
+describe('createBackpressureController', () => {
+  it('starts unpaused with fail-fast default policy', () => {
+    const c = createBackpressureController();
+    expect(c.isPaused()).toBe(false);
+    expect(c.policy()).toBe('fail-fast');
+  });
+
+  it('flips paused state + records reason', () => {
+    const c = createBackpressureController();
+    c.setPaused(true, 5_000_000);
+    expect(c.isPaused()).toBe(true);
+    expect(c.state().reasonMs).toBe(5_000_000);
+    c.setPaused(false);
+    expect(c.isPaused()).toBe(false);
+    expect(c.state().reasonMs).toBeUndefined();
+  });
+
+  it('drives the paused_total counter + paused gauge via bindMetrics', () => {
+    const c = createBackpressureController();
+    const registry = createPrometheusRegistry();
+    c.bindMetrics({
+      pausedGauge: registry.gauge('bp.active', 'active'),
+      pausedTotalCounter: registry.counter('bp.paused_total', 'paused total'),
+      dropCounter: registry.counter('bp.drops_total', 'drops total'),
+      labels: { exporter: 'splunk:bp-test' },
+    });
+    c.setPaused(true, 100);
+    c.setPaused(false);
+    c.setPaused(true, 200);
+    c.recordDrop();
+    const scrape = registry.scrape();
+    expect(scrape).toContain('bp_paused_total{exporter="splunk:bp-test"} 2');
+    expect(scrape).toContain('bp_drops_total{exporter="splunk:bp-test"} 1');
+  });
+});
+
+// ── Sink integration ───────────────────────────────────────────────────────
+
+describe('createSqliteAuditSink — back-pressure gate', () => {
+  let sink: TenantAuditSink;
+  afterEach(async () => {
+    if (sink) await sink.close();
+  });
+
+  it('throws AuditBackpressureError on record() when paused (fail-fast)', async () => {
+    const controller = createBackpressureController();
+    sink = await createSqliteAuditSink({ path: ':memory:', backpressure: controller });
+    await seed(sink, 1, 1_000_000);
+    controller.setPaused(true, 7_200_000);
+    const rec: TenantAuditRecord = {
+      kind: 'tool_call',
+      ts: 1_000_001,
+      tenantId: 'acme',
+      sessionId: 'paused',
+      tool: 'Bash',
+      permissionKey: 'bash:exec',
+      outcome: 'allow',
+    };
+    await expect(sink.record(rec)).rejects.toBeInstanceOf(AuditBackpressureError);
+    const rows = await sink.query({ tenantId: 'acme' });
+    expect(rows.length).toBe(1); // only the pre-pause row
+  });
+
+  it('silently drops + counts on record() when paused (drop policy)', async () => {
+    const controller = createBackpressureController({ policy: 'drop' });
+    const registry = createPrometheusRegistry();
+    controller.bindMetrics({
+      dropCounter: registry.counter('audit.drops_total', 'drops'),
+      labels: { exporter: 'test' },
+    });
+    sink = await createSqliteAuditSink({ path: ':memory:', backpressure: controller });
+    controller.setPaused(true, 7_200_000);
+    const rec: TenantAuditRecord = {
+      kind: 'tool_call',
+      ts: 1_000_001,
+      tenantId: 'acme',
+      sessionId: 'drop',
+      tool: 'Bash',
+      permissionKey: 'bash:exec',
+      outcome: 'allow',
+    };
+    await sink.record(rec); // does not throw
+    const rows = await sink.query({ tenantId: 'acme' });
+    expect(rows.length).toBe(0);
+    expect(registry.scrape()).toContain('audit_drops_total{exporter="test"} 1');
+  });
+
+  it('resumes normal writes once controller unpauses', async () => {
+    const controller = createBackpressureController();
+    sink = await createSqliteAuditSink({ path: ':memory:', backpressure: controller });
+    controller.setPaused(true, 7_200_000);
+    const rec: TenantAuditRecord = {
+      kind: 'tool_call',
+      ts: 1_000_000,
+      tenantId: 'acme',
+      sessionId: 's1',
+      tool: 'Bash',
+      permissionKey: 'bash:exec',
+      outcome: 'allow',
+    };
+    await expect(sink.record(rec)).rejects.toBeInstanceOf(AuditBackpressureError);
+    controller.setPaused(false);
+    await sink.record(rec); // succeeds
+    const rows = await sink.query({ tenantId: 'acme' });
+    expect(rows.length).toBe(1);
+  });
+});
+
+// ── Loop evaluator ─────────────────────────────────────────────────────────
+
+describe('startAuditExportLoop — back-pressure evaluator', () => {
+  let sink: TenantAuditSink;
+  beforeEach(async () => {
+    sink = await createSqliteAuditSink({ path: ':memory:' });
+  });
+  afterEach(async () => {
+    await sink.close();
+  });
+
+  it('engages pause when oldest unshipped row exceeds threshold, resumes when drained', async () => {
+    // Seed rows with ts anchored 2h in the past relative to our fake `now`.
+    const fakeNow = 10_000_000_000;
+    const twoHoursAgo = fakeNow - 2 * 60 * 60 * 1000;
+    await seed(sink, 3, twoHoursAgo);
+
+    const controller = createBackpressureController();
+    const exp = makeFakeExporter();
+    // Start with a stalled exporter so nothing ships.
+    exp.setBehavior(async () => ({ ok: false, retryable: true, error: 'stall' }));
+    const registry = createPrometheusRegistry();
+    const loop = startAuditExportLoop({
+      sink,
+      exporter: exp,
+      intervalMs: 60_000,
+      metrics: registry,
+      now: () => fakeNow,
+      backpressure: {
+        enabled: true,
+        pauseAfterBacklogMs: 60 * 60 * 1000, // 1h threshold
+        controller,
+        evaluateIntervalMs: 60_000,
+      },
+    });
+
+    expect(controller.isPaused()).toBe(false);
+    const backlog = await loop.evaluateBackpressureNow();
+    expect(backlog).not.toBeNull();
+    expect(backlog).toBeGreaterThanOrEqual(2 * 60 * 60 * 1000 - 5);
+    expect(controller.isPaused()).toBe(true);
+
+    // New writes now fail-fast.
+    const rec: TenantAuditRecord = {
+      kind: 'tool_call',
+      ts: fakeNow,
+      tenantId: 'acme',
+      sessionId: 'would-drop',
+      tool: 'Bash',
+      permissionKey: 'bash:exec',
+      outcome: 'allow',
+    };
+    // Attach the controller to the sink to get the fail-fast behaviour
+    // on an existing (already-seeded) sink.
+    const sinkWithBp = await createSqliteAuditSink({
+      path: ':memory:',
+      backpressure: controller,
+    });
+    await expect(sinkWithBp.record(rec)).rejects.toBeInstanceOf(AuditBackpressureError);
+    await sinkWithBp.close();
+
+    // Metrics scraped show active + paused_total.
+    const scrape = registry.scrape();
+    expect(scrape).toMatch(/declaragent_audit_backpressure_active\{[^}]*\} 1/);
+    expect(scrape).toMatch(/declaragent_audit_backpressure_paused_total\{[^}]*\} 1/);
+
+    // Unstall exporter + drain.
+    exp.setBehavior(async (b) => ({ ok: true, acked: b.length }));
+    expect(await loop.flushNow()).toBe(3);
+
+    // After draining, backlog is empty and evaluator auto-resumes.
+    const postDrain = await loop.evaluateBackpressureNow();
+    expect(postDrain).toBeNull();
+    expect(controller.isPaused()).toBe(false);
+
+    await loop.stop();
+  });
+
+  it('leaves controller alone when backlog stays under threshold', async () => {
+    const fakeNow = 10_000_000_000;
+    // 30 min old → under 1h threshold.
+    const halfHourAgo = fakeNow - 30 * 60 * 1000;
+    await seed(sink, 2, halfHourAgo);
+
+    const controller = createBackpressureController();
+    const exp = makeFakeExporter();
+    exp.setBehavior(async () => ({ ok: false, retryable: true, error: 'stall' }));
+    const loop = startAuditExportLoop({
+      sink,
+      exporter: exp,
+      intervalMs: 60_000,
+      now: () => fakeNow,
+      backpressure: {
+        enabled: true,
+        pauseAfterBacklogMs: 60 * 60 * 1000,
+        controller,
+      },
+    });
+    const backlog = await loop.evaluateBackpressureNow();
+    expect(backlog).not.toBeNull();
+    expect(controller.isPaused()).toBe(false);
+    await loop.stop();
+  });
+
+  it('no-ops cleanly when backpressure is omitted', async () => {
+    await seed(sink, 1, 1_000_000);
+    const exp = makeFakeExporter();
+    const loop = startAuditExportLoop({ sink, exporter: exp, intervalMs: 60_000 });
+    expect(await loop.evaluateBackpressureNow()).toBeNull();
+    await loop.stop();
+  });
+});

--- a/packages/core/src/audit/backpressure.ts
+++ b/packages/core/src/audit/backpressure.ts
@@ -1,0 +1,166 @@
+/**
+ * SIEM audit back-pressure controller.
+ *
+ * Shared stateful handle used by the audit sink + the export loop to
+ * coordinate a pause on NEW audit writes when the export backlog (oldest
+ * unshipped row) grows beyond a configured threshold (default 1h).
+ *
+ * Why this exists
+ * ---------------
+ * Today the export loop drains continuously — fine at low volume, but a
+ * sustained vendor outage (Splunk HEC down, Elastic cluster unreachable)
+ * backs up audit rows in SQLite without bound. On a busy single-host
+ * tenant that's tens of MB per hour; on a fleet host it can run the disk
+ * out in a working day. Back-pressure closes the valve at the intake
+ * side so the disk doesn't silently fill while Prometheus dashboards
+ * quietly show `audit.export.paused=1`.
+ *
+ * Policy
+ * ------
+ * The failure mode when paused is **fail-fast** — `sink.record()` throws
+ * an {@link AuditBackpressureError}. The alternative (drop-and-log) would
+ * silently punch holes in the hash chain, breaking `audit verify`. A
+ * caller that genuinely prefers drop-on-backlog wraps the `record()`
+ * call in its own try/catch and swallows the typed error. A dedicated
+ * `drop` policy mode is also supported for callers wiring this
+ * declaratively — it counts the drop via the provided metric and swallows
+ * the error without throwing. Pick per deployment via
+ * `CreateBackpressureControllerOptions.policy`; default `'fail-fast'`.
+ *
+ * Back-compat
+ * -----------
+ * The controller is opt-in on both {@link createSqliteAuditSink} and
+ * {@link startAuditExportLoop}. When omitted, `record()` never throws
+ * back-pressure errors + the export loop runs with its pre-0.7.4
+ * cadence.
+ *
+ * @since 0.7.4 — POST_ENTERPRISE_BACKLOG.md #11
+ */
+
+import type { Counter, Gauge } from '../events/types.js';
+import type { Logger } from '../types/logger.js';
+
+export type BackpressurePolicy = 'fail-fast' | 'drop';
+
+export interface CreateBackpressureControllerOptions {
+  /**
+   * Failure mode when paused:
+   *   - `'fail-fast'` (default): `sink.record()` throws
+   *     {@link AuditBackpressureError}. Callers decide whether to log
+   *     and swallow, or surface the failure upstream (recommended for
+   *     tool-call audit, where silent drops break verify).
+   *   - `'drop'`: `sink.record()` silently returns without persisting.
+   *     Each drop increments the configured counter (when supplied) and
+   *     logs a warning. Pick this for high-cardinality non-critical
+   *     records where dropping is cheaper than back-pressuring the
+   *     hot path.
+   */
+  policy?: BackpressurePolicy;
+  /** Optional logger for state-transition messages. */
+  logger?: Logger;
+}
+
+export interface BackpressureController {
+  /** True while new writes should be rejected. */
+  isPaused(): boolean;
+  /** Effective policy (honoured by the sink when paused). */
+  policy(): BackpressurePolicy;
+  /**
+   * Inspect the most recent state. `reasonMs` is the backlog age the
+   * controller observed at the last transition (oldest unshipped row's
+   * age, in ms) — `undefined` before the first evaluation.
+   */
+  state(): { paused: boolean; reasonMs?: number };
+  /**
+   * Flip the pause state. The loop evaluator calls this; application
+   * code should not. `reasonMs` is the observed backlog age in ms. A
+   * redundant call (same state) is a no-op.
+   */
+  setPaused(next: boolean, reasonMs?: number): void;
+  /**
+   * Register observability sinks. Called by the export loop once it has
+   * a metrics registry in hand. Subsequent state transitions fire into
+   * these. Idempotent.
+   */
+  bindMetrics(bindings: {
+    pausedGauge?: Gauge;
+    pausedTotalCounter?: Counter;
+    dropCounter?: Counter;
+    labels?: Readonly<Record<string, string>>;
+  }): void;
+  /**
+   * Increment the drop counter. Called by the sink when running in
+   * `'drop'` policy. No-op if no counter was bound.
+   */
+  recordDrop(): void;
+}
+
+/**
+ * Thrown by {@link TenantAuditSink.record} when a back-pressure
+ * controller is attached, paused, and the policy is `'fail-fast'`.
+ * Typed so callers can `instanceof`-match without string-sniffing.
+ */
+export class AuditBackpressureError extends Error {
+  readonly code = 'AUDIT_BACKPRESSURE' as const;
+  readonly backlogMs?: number;
+  constructor(message: string, backlogMs?: number) {
+    super(message);
+    this.name = 'AuditBackpressureError';
+    if (backlogMs !== undefined) this.backlogMs = backlogMs;
+  }
+}
+
+export function createBackpressureController(
+  options: CreateBackpressureControllerOptions = {},
+): BackpressureController {
+  const policyValue: BackpressurePolicy = options.policy ?? 'fail-fast';
+  const logger = options.logger;
+
+  let paused = false;
+  let reasonMs: number | undefined;
+  let pausedGauge: Gauge | undefined;
+  let pausedTotalCounter: Counter | undefined;
+  let dropCounter: Counter | undefined;
+  let metricLabels: Readonly<Record<string, string>> = {};
+
+  return {
+    isPaused: () => paused,
+    policy: () => policyValue,
+    state: () => (reasonMs === undefined ? { paused } : { paused, reasonMs }),
+    setPaused(next, nextReasonMs) {
+      if (next === paused) {
+        // Track latest reason even on redundant calls so the gauge
+        // reflects fresh backlog numbers on a sustained pause.
+        if (next && nextReasonMs !== undefined) reasonMs = nextReasonMs;
+        return;
+      }
+      paused = next;
+      if (nextReasonMs !== undefined) reasonMs = nextReasonMs;
+      pausedGauge?.set(next ? 1 : 0, metricLabels);
+      if (next) {
+        pausedTotalCounter?.inc(1, metricLabels);
+        logger?.warn('audit.backpressure.paused', {
+          policy: policyValue,
+          backlogMs: reasonMs,
+        });
+      } else {
+        logger?.info('audit.backpressure.resumed', {
+          policy: policyValue,
+          lastBacklogMs: reasonMs,
+        });
+        reasonMs = undefined;
+      }
+    },
+    bindMetrics({ pausedGauge: pg, pausedTotalCounter: pc, dropCounter: dc, labels = {} }) {
+      pausedGauge = pg;
+      pausedTotalCounter = pc;
+      dropCounter = dc;
+      metricLabels = labels;
+      // Prime the gauge so scrapers see `0` before the first transition.
+      pg?.set(paused ? 1 : 0, metricLabels);
+    },
+    recordDrop() {
+      dropCounter?.inc(1, metricLabels);
+    },
+  };
+}

--- a/packages/core/src/audit/exporter-loop.ts
+++ b/packages/core/src/audit/exporter-loop.ts
@@ -19,14 +19,91 @@
  * the monotonic `seq`, so downstream dedup is cheap (`_id` in Elastic,
  * an index-time lookup in Splunk/Datadog).
  *
+ * Back-pressure (0.7.4 — POST_ENTERPRISE_BACKLOG.md #11)
+ * ------------------------------------------------------
+ * An optional {@link BackpressureController} pauses NEW audit writes
+ * when the oldest unshipped row's age exceeds
+ * `backpressure.pauseAfterBacklogMs` (default 1 h). The loop evaluates
+ * the threshold on a separate timer (`evaluateIntervalMs`, default
+ * 30 s) so intake gating is decoupled from export cadence; the export
+ * loop keeps draining at full speed while paused so the queue
+ * eventually unblocks itself. The controller also resumes
+ * automatically once the oldest unshipped row ages back under
+ * threshold.
+ *
+ * Adaptive batch interval (0.7.4 — POST_ENTERPRISE_BACKLOG.md #12)
+ * ---------------------------------------------------------------
+ * At 10k tool-calls/sec a fixed 10 s interval produces 100k-row
+ * batches that OOM vendor shippers. Instead, the loop runs a simple
+ * proportional controller:
+ *
+ *   next = clamp(current * (targetRows / rowsShipped), min, max)
+ *
+ * A burst that ships `batchSize` rows (queue was deeper than the
+ * batch cap) compresses the next interval toward `minIntervalMs`;
+ * steady state where the batch comes back `targetRows`-sized stays at
+ * the current cadence; quiet queues (few rows) relax toward
+ * `maxIntervalMs`. Empty queues skip adjustment + stay at
+ * `maxIntervalMs` so an idle tenant isn't polling every 200 ms.
+ *
  * @since 0.6.x — Enterprise Production Plan §3 Item #10
+ * @since 0.7.4 — POST_ENTERPRISE_BACKLOG.md #11, #12
  */
 
+import type { Histogram } from '../events/types.js';
 import type { PrometheusRegistry } from '../observability/prometheus.js';
 import type { Logger } from '../types/logger.js';
+import type { BackpressureController } from './backpressure.js';
 import { toExportEntry } from './exporters/exporter.js';
 import type { AuditExporter } from './exporters/exporter.js';
 import type { TenantAuditSink } from './types.js';
+
+export interface AuditExportLoopBackpressureOptions {
+  /** Enable back-pressure gating. Default `false` (opt-in). */
+  enabled?: boolean;
+  /**
+   * Backlog-age threshold in ms. When the oldest unshipped audit row
+   * is older than this, the controller pauses new writes. Default
+   * `3_600_000` (1 h).
+   */
+  pauseAfterBacklogMs?: number;
+  /**
+   * How often to evaluate the threshold, in ms. Default `30_000`
+   * (30 s). A small interval means the pause kicks in sooner after a
+   * sustained outage but adds one SQLite `MIN(ts)` query per interval
+   * — cheap even at 10k rps.
+   */
+  evaluateIntervalMs?: number;
+  /**
+   * Shared back-pressure controller. Construct via
+   * {@link createBackpressureController} and pass the same instance to
+   * the sink via `CreateSqliteAuditSinkOptions.backpressure`.
+   */
+  controller: BackpressureController;
+}
+
+export interface AuditExportLoopBatchOptions {
+  /**
+   * Minimum interval the proportional controller can shrink to. Default
+   * `200` ms. Below this the vendor HTTP overhead dominates and we
+   * start paying latency to ship a handful of rows.
+   */
+  minIntervalMs?: number;
+  /**
+   * Maximum interval the proportional controller can relax to. Default
+   * `10_000` ms — matches the original fixed cadence so the adaptive
+   * path never produces a *longer* gap than today's behaviour.
+   */
+  maxIntervalMs?: number;
+  /**
+   * Target batch size (rows). The controller's setpoint — we pick the
+   * next interval so the next batch is approximately this size,
+   * assuming steady-state arrival rate. Default `500` (matches
+   * `batchSize` default; the controller never asks the sink for more
+   * rows than `batchSize` per tick).
+   */
+  targetBatchRows?: number;
+}
 
 export interface AuditExportLoopOptions {
   sink: TenantAuditSink;
@@ -46,6 +123,21 @@ export interface AuditExportLoopOptions {
   metrics?: PrometheusRegistry;
   /** Clock injection for tests. */
   now?: () => number;
+  /**
+   * SIEM back-pressure. Pauses NEW audit writes when the oldest
+   * unshipped row's age exceeds a configured threshold.
+   *
+   * @since 0.7.4 — POST_ENTERPRISE_BACKLOG.md #11
+   */
+  backpressure?: AuditExportLoopBackpressureOptions;
+  /**
+   * Adaptive batch-interval controller. Adjusts the tick cadence based
+   * on rows-shipped-per-batch so bursts compress + steady state relaxes.
+   * Omitted = fixed-cadence behaviour (pre-0.7.4).
+   *
+   * @since 0.7.4 — POST_ENTERPRISE_BACKLOG.md #12
+   */
+  batch?: AuditExportLoopBatchOptions;
 }
 
 export interface AuditExportLoopHandle {
@@ -61,6 +153,23 @@ export interface AuditExportLoopHandle {
    * for tests; production callers should rely on the interval.
    */
   flushNow(): Promise<number>;
+  /**
+   * Force a back-pressure evaluation (reads the sink's oldest unshipped
+   * row + flips the controller). Returns the observed backlog age in
+   * ms, or `null` when the queue is empty. Primarily for tests;
+   * production callers rely on the evaluator timer.
+   *
+   * @since 0.7.4
+   */
+  evaluateBackpressureNow(): Promise<number | null>;
+  /**
+   * Current tick cadence in ms. Reflects the adaptive controller's
+   * latest decision when `batch` was supplied; otherwise returns the
+   * fixed `intervalMs`. Useful for assertions in tests.
+   *
+   * @since 0.7.4
+   */
+  currentIntervalMs(): number;
 }
 
 const DEFAULT_INTERVAL_MS = 10_000;
@@ -68,6 +177,17 @@ const DEFAULT_BATCH_SIZE = 500;
 const DEFAULT_MAX_FAILURES = 5;
 const DEFAULT_INITIAL_BACKOFF_MS = 1_000;
 const DEFAULT_MAX_BACKOFF_MS = 30_000;
+const DEFAULT_BP_PAUSE_AFTER_MS = 60 * 60 * 1_000;
+const DEFAULT_BP_EVALUATE_MS = 30_000;
+const DEFAULT_BATCH_MIN_INTERVAL_MS = 200;
+const DEFAULT_BATCH_MAX_INTERVAL_MS = 10_000;
+const DEFAULT_BATCH_TARGET_ROWS = 500;
+
+// Histogram bucket boundaries for batch rows — geometric up to 50k so
+// the +Inf overflow only catches truly pathological spikes.
+const BATCH_ROW_BUCKETS: readonly number[] = [
+  1, 10, 50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000, 25_000, 50_000,
+];
 
 export function startAuditExportLoop(options: AuditExportLoopOptions): AuditExportLoopHandle {
   const {
@@ -81,6 +201,8 @@ export function startAuditExportLoop(options: AuditExportLoopOptions): AuditExpo
     logger,
     metrics,
     now = Date.now,
+    backpressure,
+    batch,
   } = options;
 
   if (typeof sink.readExportCursor !== 'function' || typeof sink.writeExportCursor !== 'function') {
@@ -109,12 +231,77 @@ export function startAuditExportLoop(options: AuditExportLoopOptions): AuditExpo
     "Highest audit seq the exporter has ack'd",
   );
 
+  // #11 — back-pressure metrics
+  const bpPausedTotalCounter = metrics?.counter(
+    'declaragent.audit.backpressure.paused_total',
+    'Number of times the audit-intake back-pressure gate has engaged',
+  );
+  const bpActiveGauge = metrics?.gauge(
+    'declaragent.audit.backpressure.active',
+    'Audit-intake back-pressure active (1=paused, 0=running)',
+  );
+  const bpDropCounter = metrics?.counter(
+    'declaragent.audit.backpressure.drops_total',
+    'Audit records dropped while back-pressure was active (drop policy)',
+  );
+  const bpBacklogMsGauge = metrics?.gauge(
+    'declaragent.audit.backpressure.backlog_ms',
+    'Age in ms of the oldest unshipped audit row (most recent evaluator sample)',
+  );
+
+  // #12 — adaptive batch metrics
+  const batchIntervalGauge = metrics?.gauge(
+    'declaragent.audit.batch.interval_ms',
+    'Current exporter tick interval, in ms (adaptive when `batch` is configured)',
+  );
+  let batchRowsHist: Histogram | undefined;
+  if (metrics) {
+    batchRowsHist = metrics.histogram(
+      'declaragent.audit.batch.rows',
+      'Rows per audit export batch (0 = empty tick)',
+      BATCH_ROW_BUCKETS,
+    );
+  }
+
+  // Back-pressure wiring
+  const bpOptions = backpressure?.enabled ? backpressure : undefined;
+  const bpPauseAfterMs = bpOptions?.pauseAfterBacklogMs ?? DEFAULT_BP_PAUSE_AFTER_MS;
+  const bpEvaluateMs = bpOptions?.evaluateIntervalMs ?? DEFAULT_BP_EVALUATE_MS;
+  const bpController = bpOptions?.controller;
+  if (bpController && metrics) {
+    const labels = { exporter: exporter.name, vendor: exporter.vendor };
+    bpController.bindMetrics({
+      ...(bpActiveGauge && { pausedGauge: bpActiveGauge }),
+      ...(bpPausedTotalCounter && { pausedTotalCounter: bpPausedTotalCounter }),
+      ...(bpDropCounter && { dropCounter: bpDropCounter }),
+      labels,
+    });
+  }
+
+  // Adaptive batch wiring
+  const batchEnabled = batch !== undefined;
+  const batchMin = batch?.minIntervalMs ?? DEFAULT_BATCH_MIN_INTERVAL_MS;
+  const batchMax = batch?.maxIntervalMs ?? DEFAULT_BATCH_MAX_INTERVAL_MS;
+  const batchTarget = batch?.targetBatchRows ?? DEFAULT_BATCH_TARGET_ROWS;
+  // Seed the adaptive cadence at the midpoint or the supplied fixed interval,
+  // clamped. Matches operator intuition: "if I set intervalMs=5s, I expect
+  // steady state to run near that".
+  let currentInterval = batchEnabled
+    ? Math.max(batchMin, Math.min(batchMax, intervalMs))
+    : intervalMs;
+
+  batchIntervalGauge?.set(currentInterval, {
+    exporter: exporter.name,
+    vendor: exporter.vendor,
+  });
+
   let paused = false;
   let consecutiveFailures = 0;
   let nextTickBackoffMs = 0;
   let stopped = false;
   let ticking = false;
   let timer: ReturnType<typeof setTimeout> | null = null;
+  let bpTimer: ReturnType<typeof setTimeout> | null = null;
 
   function scheduleNext(delayMs: number): void {
     if (stopped) return;
@@ -147,6 +334,44 @@ export function startAuditExportLoop(options: AuditExportLoopOptions): AuditExpo
     }
   }
 
+  /**
+   * Simple proportional controller for #12. We want the *next* batch
+   * to land at `targetBatchRows`. The naive estimator is:
+   *
+   *   arrivalRatePerMs ≈ shipped / currentInterval
+   *   nextInterval     ≈ targetRows / arrivalRatePerMs
+   *                    = currentInterval * (targetRows / shipped)
+   *
+   * Clamped into [min, max]. `shipped === 0` skips adjustment (idle
+   * queue) and `shipped === batchSize` implies the cap bit — pressure
+   * was deeper than we could drain, so push hard toward `min`.
+   */
+  function adjustIntervalAfterTick(shipped: number): void {
+    if (!batchEnabled) return;
+    let next = currentInterval;
+    if (shipped === 0) {
+      // Idle queue → relax toward max.
+      next = Math.min(batchMax, Math.max(batchMin, currentInterval * 2));
+    } else if (shipped >= batchSize) {
+      // Hit the batch cap → under-draining. Cut the interval hard.
+      next = Math.max(batchMin, Math.floor(currentInterval / 2));
+    } else {
+      const ratio = batchTarget / shipped;
+      next = Math.max(batchMin, Math.min(batchMax, Math.floor(currentInterval * ratio)));
+    }
+    if (next !== currentInterval) {
+      currentInterval = next;
+      batchIntervalGauge?.set(currentInterval, {
+        exporter: exporter.name,
+        vendor: exporter.vendor,
+      });
+    }
+  }
+
+  function effectiveTickInterval(): number {
+    return batchEnabled ? currentInterval : intervalMs;
+  }
+
   async function runTick(): Promise<number> {
     if (stopped || ticking) return 0;
     ticking = true;
@@ -160,10 +385,18 @@ export function startAuditExportLoop(options: AuditExportLoopOptions): AuditExpo
         order: 'asc',
         limit: batchSize,
       });
+      // Record batch-size regardless of ack outcome — observability
+      // should show the *attempt* size so bursts are visible even
+      // when the vendor is throwing 5xx.
+      batchRowsHist?.observe(stored.length, {
+        exporter: exporter.name,
+        vendor: exporter.vendor,
+      });
       if (stored.length === 0) {
         // Nothing to push — reset any backoff so we come back on normal cadence.
         nextTickBackoffMs = 0;
         consecutiveFailures = 0;
+        adjustIntervalAfterTick(0);
         return 0;
       }
       const entries = stored.map(toExportEntry);
@@ -180,6 +413,7 @@ export function startAuditExportLoop(options: AuditExportLoopOptions): AuditExpo
         }
         consecutiveFailures = 0;
         nextTickBackoffMs = 0;
+        adjustIntervalAfterTick(acked);
         logger?.debug('audit.export.tick', {
           exporter: exporter.name,
           vendor: exporter.vendor,
@@ -187,6 +421,7 @@ export function startAuditExportLoop(options: AuditExportLoopOptions): AuditExpo
           acked,
           firstSeq: entries[0]?.seq,
           lastSeq: entries[entries.length - 1]?.seq,
+          intervalMs: currentInterval,
         });
       } else {
         failureCounter?.inc(1, {
@@ -238,11 +473,8 @@ export function startAuditExportLoop(options: AuditExportLoopOptions): AuditExpo
     } finally {
       ticking = false;
       if (!stopped) {
-        const delay = paused
-          ? intervalMs * 6
-          : nextTickBackoffMs > 0
-            ? nextTickBackoffMs
-            : intervalMs;
+        const base = effectiveTickInterval();
+        const delay = paused ? base * 6 : nextTickBackoffMs > 0 ? nextTickBackoffMs : base;
         scheduleNext(delay);
       }
     }
@@ -253,10 +485,58 @@ export function startAuditExportLoop(options: AuditExportLoopOptions): AuditExpo
     return acked;
   }
 
+  async function evaluateBackpressure(): Promise<number | null> {
+    if (!bpController) return null;
+    if (typeof sink.oldestUnshippedMs !== 'function') return null;
+    let oldest: number | null;
+    try {
+      oldest = await sink.oldestUnshippedMs(exporter.name);
+    } catch (err) {
+      logger?.warn('audit.backpressure.evaluate-failed', {
+        exporter: exporter.name,
+        vendor: exporter.vendor,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }
+    if (oldest === null) {
+      // Queue is empty — unconditionally resume.
+      bpBacklogMsGauge?.set(0, { exporter: exporter.name, vendor: exporter.vendor });
+      if (bpController.isPaused()) bpController.setPaused(false);
+      return null;
+    }
+    const backlogMs = Math.max(0, now() - oldest);
+    bpBacklogMsGauge?.set(backlogMs, { exporter: exporter.name, vendor: exporter.vendor });
+    if (backlogMs >= bpPauseAfterMs) {
+      bpController.setPaused(true, backlogMs);
+    } else {
+      if (bpController.isPaused()) bpController.setPaused(false, backlogMs);
+    }
+    return backlogMs;
+  }
+
+  function scheduleBackpressureEvaluation(): void {
+    if (stopped || !bpController) return;
+    bpTimer = setTimeout(() => {
+      bpTimer = null;
+      void (async () => {
+        await evaluateBackpressure();
+        scheduleBackpressureEvaluation();
+      })();
+    }, bpEvaluateMs);
+    if (typeof (bpTimer as { unref?: () => void }).unref === 'function') {
+      (bpTimer as { unref: () => void }).unref();
+    }
+  }
+
   // Kick off the first tick on the normal cadence. A zero-delay would
-  // front-load a blocking HTTP call into the `up` boot sequence; 10s
-  // later gives the rest of the daemon time to bind cleanly.
-  scheduleNext(intervalMs);
+  // front-load a blocking HTTP call into the `up` boot sequence; one
+  // interval later gives the rest of the daemon time to bind cleanly.
+  scheduleNext(effectiveTickInterval());
+  // Start the back-pressure evaluator if configured.
+  if (bpController) {
+    scheduleBackpressureEvaluation();
+  }
 
   return {
     isPaused: () => paused,
@@ -274,11 +554,17 @@ export function startAuditExportLoop(options: AuditExportLoopOptions): AuditExpo
         clearTimeout(timer);
         timer = null;
       }
+      if (bpTimer) {
+        clearTimeout(bpTimer);
+        bpTimer = null;
+      }
       // Let the currently-running tick (if any) finish before returning.
       while (ticking) {
         await new Promise((r) => setTimeout(r, 10));
       }
     },
     flushNow: async () => runTick(),
+    evaluateBackpressureNow: async () => evaluateBackpressure(),
+    currentIntervalMs: () => effectiveTickInterval(),
   };
 }

--- a/packages/core/src/audit/index.ts
+++ b/packages/core/src/audit/index.ts
@@ -30,9 +30,20 @@ export { createDatadogExporter } from './exporters/datadog.js';
 export type { CreateDatadogExporterOptions } from './exporters/datadog.js';
 export { startAuditExportLoop } from './exporter-loop.js';
 export type {
+  AuditExportLoopBackpressureOptions,
+  AuditExportLoopBatchOptions,
   AuditExportLoopHandle,
   AuditExportLoopOptions,
 } from './exporter-loop.js';
+export {
+  AuditBackpressureError,
+  createBackpressureController,
+} from './backpressure.js';
+export type {
+  BackpressureController,
+  BackpressurePolicy,
+  CreateBackpressureControllerOptions,
+} from './backpressure.js';
 export {
   canonicalizeRecord,
   computeRecordHash,

--- a/packages/core/src/audit/sqlite-sink.ts
+++ b/packages/core/src/audit/sqlite-sink.ts
@@ -1,4 +1,6 @@
 import { Database } from 'bun:sqlite';
+import type { Logger } from '../types/logger.js';
+import { AuditBackpressureError, type BackpressureController } from './backpressure.js';
 import { canonicalizeRecord, computeRecordHash, verifyEntries } from './chain-verify.js';
 import type {
   EraseOptions,
@@ -32,6 +34,26 @@ export interface CreateSqliteAuditSinkOptions {
   path: string;
   /** Injected clock (only used for timestamps the caller omits). */
   now?: () => number;
+  /**
+   * Optional SIEM back-pressure controller. When supplied, `record()`
+   * consults {@link BackpressureController.isPaused} before every write:
+   *
+   *   - `policy = 'fail-fast'` (default): throws {@link AuditBackpressureError}.
+   *   - `policy = 'drop'`:   silently drops + increments the controller's
+   *     drop counter (see {@link createBackpressureController}).
+   *
+   * Opt-in — undefined preserves pre-0.7.4 behaviour (unbounded intake).
+   *
+   * @since 0.7.4 — POST_ENTERPRISE_BACKLOG.md #11
+   */
+  backpressure?: BackpressureController;
+  /**
+   * Optional logger threaded into the back-pressure `'drop'` path. The
+   * controller uses this for transition logs too, so most deployments
+   * will pass the same logger to the controller itself; this is here
+   * for the rare case where the sink wants extra visibility on drops.
+   */
+  logger?: Logger;
 }
 
 interface RowShape {
@@ -87,6 +109,8 @@ export async function createSqliteAuditSink(
   db.exec('PRAGMA synchronous = NORMAL;');
   db.exec(SCHEMA);
   const now = options.now ?? Date.now;
+  const backpressure = options.backpressure;
+  const logger = options.logger;
 
   const tailStmt = db.prepare('SELECT record_hash FROM audit_records ORDER BY seq DESC LIMIT 1');
   function latestHash(): string {
@@ -100,6 +124,26 @@ export async function createSqliteAuditSink(
   );
 
   async function record(input: TenantAuditRecord): Promise<void> {
+    // Back-pressure gate — when the SIEM backlog is too old, either
+    // fail-fast to surface the outage or drop + log depending on the
+    // controller's configured policy. See `backpressure.ts`.
+    if (backpressure?.isPaused()) {
+      const { reasonMs } = backpressure.state();
+      if (backpressure.policy() === 'drop') {
+        backpressure.recordDrop();
+        logger?.warn('audit.backpressure.drop', {
+          kind: input.kind,
+          backlogMs: reasonMs,
+        });
+        return;
+      }
+      throw new AuditBackpressureError(
+        `audit sink paused — SIEM export backlog exceeds threshold${
+          reasonMs !== undefined ? ` (oldest unshipped row age ${reasonMs}ms)` : ''
+        }`,
+        reasonMs,
+      );
+    }
     const ts = (input as { ts?: number }).ts ?? now();
     const stamped: TenantAuditRecord = { ...input, ts } as TenantAuditRecord;
     const json = canonicalizeRecord(stamped);
@@ -222,6 +266,15 @@ export async function createSqliteAuditSink(
                          ELSE audit_export_cursor.updated_at END`,
   );
 
+  const oldestUnshippedStmt = db.prepare('SELECT MIN(ts) AS ts FROM audit_records WHERE seq > ?');
+  async function oldestUnshippedMs(exporterName: string): Promise<number | null> {
+    const cursor = await readExportCursor(exporterName);
+    const sinceSeq = cursor?.lastSeq ?? 0;
+    const row = oldestUnshippedStmt.get(sinceSeq) as { ts: number | null } | null;
+    if (!row || row.ts === null) return null;
+    return row.ts;
+  }
+
   async function readExportCursor(exporterName: string): Promise<ExportCursor | null> {
     const row = readCursorStmt.get(exporterName) as {
       exporter_name: string;
@@ -244,7 +297,17 @@ export async function createSqliteAuditSink(
     db.close();
   }
 
-  return { record, query, erase, verify, prune, readExportCursor, writeExportCursor, close };
+  return {
+    record,
+    query,
+    erase,
+    verify,
+    prune,
+    readExportCursor,
+    writeExportCursor,
+    oldestUnshippedMs,
+    close,
+  };
 }
 
 /**

--- a/packages/core/src/audit/types.ts
+++ b/packages/core/src/audit/types.ts
@@ -338,6 +338,19 @@ export interface TenantAuditSink {
    * @since 0.6.x — Enterprise Production Plan §3 Item #10
    */
   writeExportCursor?(exporterName: string, lastSeq: number): Promise<void>;
+  /**
+   * Timestamp (ms) of the oldest audit row that has not yet been
+   * acknowledged by the named exporter's cursor, or `null` when the
+   * queue is empty. Used by the SIEM back-pressure evaluator on the
+   * export loop.
+   *
+   * Implementations that don't track a cursor may omit this — the
+   * export loop skips back-pressure evaluation when the method is
+   * absent.
+   *
+   * @since 0.7.4 — POST_ENTERPRISE_BACKLOG.md #11
+   */
+  oldestUnshippedMs?(exporterName: string): Promise<number | null>;
   /** Graceful shutdown. */
   close(): Promise<void> | void;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -101,8 +101,10 @@ export type {
   VaultTokenAuth,
 } from './secrets/index.js';
 export {
+  AuditBackpressureError,
   canonicalizeRecord as canonicalizeAuditRecord,
   computeRecordHash as computeAuditRecordHash,
+  createBackpressureController,
   createDatadogExporter,
   createElasticExporter,
   createSplunkExporter,
@@ -116,11 +118,16 @@ export {
 } from './audit/index.js';
 export type {
   AuditExportEntry,
+  AuditExportLoopBackpressureOptions,
+  AuditExportLoopBatchOptions,
   AuditExportLoopHandle,
   AuditExportLoopOptions,
   AuditExporter,
   AuthCheckAuditRecord,
+  BackpressureController,
+  BackpressurePolicy,
   CapabilitySchemaViolationAuditRecord,
+  CreateBackpressureControllerOptions,
   CreateDatadogExporterOptions,
   CreateElasticExporterOptions,
   CreateSplunkExporterOptions,


### PR DESCRIPTION
## Summary

Ships [POST_ENTERPRISE_BACKLOG.md](../blob/main/docs/POST_ENTERPRISE_BACKLOG.md) rows **#11** + **#12** — bundled because both touch the same SIEM export file(s).

### #11 — Back-pressure policy (default 1 h backlog threshold)
- New `BackpressureController` (`createBackpressureController`) coordinates a pause on NEW audit writes when the SIEM export backlog (oldest unshipped row age) exceeds a configurable threshold (default 1 h).
- `createSqliteAuditSink({ backpressure })` gates `record()` before every write. Two policies:
  - `fail-fast` (default): `sink.record()` throws typed `AuditBackpressureError` so callers surface the outage. Preserves the hash-chain invariant.
  - `drop` (opt-in): silently increments a Prometheus drop counter. For high-cardinality non-critical records.
- `startAuditExportLoop({ backpressure: { enabled, pauseAfterBacklogMs, evaluateIntervalMs, controller } })` evaluates `sink.oldestUnshippedMs()` on a dedicated 30 s timer (configurable). Pause engages above threshold; auto-resumes once queue drains under.
- Export loop keeps draining at full speed while paused so the queue unblocks itself.

### #12 — Adaptive batch interval
- `startAuditExportLoop({ batch: { minIntervalMs, maxIntervalMs, targetBatchRows } })` replaces the fixed cadence with a simple proportional controller:
  - Batch hits `batchSize` cap (under-draining) → halve interval toward `minIntervalMs` (default 200 ms).
  - Empty queue → double interval toward `maxIntervalMs` (default 10 s).
  - Shipped ≈ target → stay put.
- Solves the 10k tool-calls/sec → 100k-row-batches-OOM-the-shipper problem.

### Metrics (exposed through existing Prometheus registry → picks up in Slice 3 fan-out automatically)
- `declaragent.audit.backpressure.paused_total` counter
- `declaragent.audit.backpressure.active` gauge
- `declaragent.audit.backpressure.drops_total` counter
- `declaragent.audit.backpressure.backlog_ms` gauge
- `declaragent.audit.batch.interval_ms` gauge
- `declaragent.audit.batch.rows` histogram (geometric buckets up to 50k)

### Back-compat
Both features are opt-in; omitting the new options preserves pre-0.7.4 behaviour (unbounded intake, fixed 10 s cadence).

### Files changed
- `packages/core/src/audit/backpressure.ts` (new) — controller + `AuditBackpressureError`
- `packages/core/src/audit/backpressure.test.ts` (new) — 9 tests
- `packages/core/src/audit/adaptive-batch.test.ts` (new) — 6 tests
- `packages/core/src/audit/sqlite-sink.ts` — `backpressure` option + `oldestUnshippedMs()`
- `packages/core/src/audit/exporter-loop.ts` — evaluator timer + adaptive controller + metrics
- `packages/core/src/audit/index.ts` — re-exports
- `packages/core/src/audit/types.ts` — `oldestUnshippedMs()` on `TenantAuditSink`
- `packages/core/src/index.ts` — core surface re-exports
- `docs/POST_ENTERPRISE_BACKLOG.md` — rows #11 + #12 checked, banner +2 shipped

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun test` — **2790 pass / 41 skip / 0 fail** (15 new tests added)
- [x] `bun run lint` — passes
- [x] Back-pressure engages when threshold crossed, resumes on drain
- [x] `sink.record()` fail-fast throws typed error; drop policy counts silently
- [x] Adaptive interval contracts toward min on sustained bursts, relaxes toward max on idle queue, stays at steady state when shipped ≈ target
- [x] Metrics exposed on the shared `PrometheusRegistry` so Slice 3 cross-host fan-out (#50) picks them up without extra plumbing

🤖 Generated with [Claude Code](https://claude.com/claude-code)