### PR TITLE
docs(cookbook): add 5 enterprise recipes — GitOps, SIEM, zero-trust, cross-host, Grafana

### DIFF
--- a/docs-site/docs/cookbook/cross-host-fleet-kafka.mdx
+++ b/docs-site/docs/cookbook/cross-host-fleet-kafka.mdx
@@ -1,0 +1,160 @@
+---
+id: cross-host-fleet-kafka
+title: Cross-host fleet on Kafka with unified observability
+sidebar_label: Cross-host fleet (Kafka)
+---
+
+# Run a fleet across hosts, observe it as one
+
+Production fleets don't run on one host. This recipe takes a working `fleet-starter` and splits it across three hosts talking over Kafka — then uses `fleet.yaml#hosts[]` to let one operator run `declaragent fleet ps / events / dlq / logs` **once** and see every host.
+
+Under the hood this is Slice 3 cross-host fan-out (`packages/cli/src/fleet-cross-host-cli.ts`) + the `CrossHostControlPlaneClient`. One bad host is tagged in the output; survivors still return results.
+
+## Prerequisites
+
+- A Kafka cluster (MSK / Confluent Cloud / self-hosted; SASL_SSL supported).
+- Three daemon hosts that can each reach Kafka.
+- Network: each host exposes its control plane on `:9464`. Bearer tokens must not cross the internet in cleartext — terminate TLS at an ingress or use `DECLARAGENT_CONTROL_PLANE_BIND=127.0.0.1` + a sidecar.
+- `@declaragent/cli ≥ 0.7.4` on each host.
+
+## Step 1 — Pick the broker transport
+
+In each agent's `rpc-peers.yaml`, point the peer at Kafka:
+
+```yaml
+# agents/pr-reviewer/rpc-peers.yaml
+peers:
+  - id: concierge
+    transport: kafka
+    topic: agents.concierge.inbound
+    bootstrap: kafka-prod.acme.internal:9093
+    sasl:
+      mechanism: SCRAM-SHA-512
+      username: env:KAFKA_USER
+      password: env:KAFKA_PASS
+    ssl: true
+    auth:
+      enabled: true
+      provider: hs256
+      secret: env:AGENT_RPC_SHARED_SECRET
+```
+
+NATS, JetStream, SQS, AMQP, and MQTT transports ship with the same shape — swap `transport:` and the broker-specific keys.
+
+## Step 2 — Declare hosts in `fleet.yaml`
+
+```yaml
+# fleet.yaml
+version: 1
+name: orders
+agents:
+  - { id: concierge,   path: ./agents/concierge }
+  - { id: pr-reviewer, path: ./agents/pr-reviewer }
+  - { id: triage,      path: ./agents/triage }
+
+hosts:
+  - name: prod-us-east-1
+    url: https://declaragent-use1.acme.internal:9464
+    auth: { bearer: env:DECLARA_TOKEN_USE1 }
+    timeoutMs: 5000
+    region: us-east-1
+  - name: prod-us-west-2
+    url: https://declaragent-usw2.acme.internal:9464
+    auth: { bearer: env:DECLARA_TOKEN_USW2 }
+    region: us-west-2
+  - name: prod-eu-west-1
+    url: https://declaragent-euw1.acme.internal:9464
+    auth: { bearer: env:DECLARA_TOKEN_EUW1 }
+    region: eu-west-1
+```
+
+Schema constraints (`packages/core/src/fleet/manifest-schema.ts`):
+
+- `name` must be URL-safe (no spaces) and unique.
+- `url` must be a valid http/https URL.
+- `auth.bearer` accepts `env:FOO` — resolved at invocation time, never logged.
+
+## Step 3 — Deploy per-host
+
+Each host runs the same artifact (built via [GitOps](/cookbook/gitops-argocd-flux)). No cross-host state; Kafka is the source of truth for inter-agent messages.
+
+## Step 4 — Observe the whole fleet
+
+From **any** operator workstation with a checkout of the fleet repo:
+
+```bash
+# Every running agent across all three hosts
+declaragent fleet ps
+
+# Merged audit event stream
+declaragent fleet events --json | jq '. | select(.kind == "tool_call")'
+
+# Cross-host DLQ snapshot (ingress + dispatch)
+declaragent fleet dlq list --kind dispatch
+
+# Tail logs — capped at 50 watchers total, coalesced per-agent
+declaragent fleet logs -f
+```
+
+Scope to one host with `--host <name>`:
+
+```bash
+declaragent fleet events --host prod-eu-west-1
+declaragent fleet logs   --host prod-us-east-1 -f
+```
+
+Machine-readable output for dashboards and CI checks:
+
+```bash
+declaragent fleet ps --json | jq '.hosts[] | {host: .name, up: .agents | length}'
+```
+
+## Step 5 — Cross-host DLQ mutations (0.7.5+)
+
+Requeue a stuck dispatch-DLQ row on whichever host holds it — the command locates the host automatically:
+
+```bash
+declaragent fleet dlq requeue --kind dispatch <id>
+declaragent fleet dlq drop    --kind dispatch <id> --reason "poisoned payload"
+```
+
+Both mutations are audited with `host = <name>` so your SIEM can attribute the operator action (`packages/core/src/audit/types.ts:184`).
+
+## Partial failure — one host unreachable
+
+When a host is down, cross-host verbs degrade gracefully:
+
+```bash
+$ declaragent fleet ps --json | jq '.failures'
+[
+  { "host": "prod-eu-west-1", "error": "ETIMEDOUT" }
+]
+```
+
+Survivors still return. The exit code is non-zero so CI catches the regression without losing the data from healthy hosts.
+
+## Metrics to watch
+
+Wire the [Grafana dashboard](/cookbook/grafana-dashboard-import) — row 3 ("Rate limits + dispatch") aggregates across all hosts scraped by Prometheus. Key per-host alerts:
+
+| Metric | Alert |
+| --- | --- |
+| `source_messages_dlq_total{transport="kafka"}` | Rate > 0 for 5 min |
+| `source_inflight{transport="kafka"}` | Stuck > N for 10 min = consumer stall |
+| Up probe on `:9464/health` | Down > 2m = host evacuated from `hosts[]` |
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `no hosts: block in fleet.yaml — use declaragent ps for local view` | `hosts[]` missing | Add the block; cross-host verbs are opt-in |
+| One host times out every call | `timeoutMs` too tight for a cross-region hop | Raise to 15000 for EU↔US |
+| Merged events sorted wrong | Clock skew between hosts | Enforce NTP; each event carries its own `ts` so ingest-order is deterministic |
+| `AUTH_REJECTED` on RPC at boot | Kafka peer missing an `auth:` block | See [Zero-trust RPC migration](/cookbook/zero-trust-rpc-migration) |
+
+## Related
+
+- [Reference → Fleet manifest](/reference/fleet).
+- [GitOps deploy](/cookbook/gitops-argocd-flux).
+- [Grafana dashboard import](/cookbook/grafana-dashboard-import).
+- [`kafka-pipeline` template](/cookbook/kafka-pipeline) — single-agent Kafka source.

--- a/docs-site/docs/cookbook/gitops-argocd-flux.mdx
+++ b/docs-site/docs/cookbook/gitops-argocd-flux.mdx
@@ -1,0 +1,174 @@
+---
+id: gitops-argocd-flux
+title: GitOps deploy with ArgoCD or Flux
+sidebar_label: GitOps — ArgoCD / Flux
+---
+
+# GitOps deploy with ArgoCD or Flux
+
+Your platform team already runs ArgoCD or Flux. Declaragent doesn't try to replace that — `declaragent fleet render` emits vanilla Kubernetes manifests (Helm chart **or** Kustomize base) and your existing reconciler does the deploy. Agents become a git artifact like any other workload.
+
+This recipe takes a fleet from `fleet.yaml` to "Argo reconciled, drift-detected, rollback-able" in three commits.
+
+## Prerequisites
+
+- A fleet repo with `fleet.yaml` + per-agent `agent.yaml` (e.g. the [`fleet-starter`](/cookbook/fleet-starter) template).
+- A Kubernetes cluster with **either** ArgoCD **or** Flux v2 installed.
+- Prometheus Operator (for the ServiceMonitor output) — optional, see `--no-servicemonitor` below.
+- A secrets reconciler: External Secrets Operator, Sealed Secrets, or Vault Agent Injector. Declaragent **never** renders live credentials into manifests.
+
+## Step 1 — Render
+
+```bash
+# Helm chart (default)
+declaragent fleet render --target k8s --format helm      --out ./deploy/chart
+
+# Or Kustomize base — pairs well with ApplicationSet per-env overlays
+declaragent fleet render --target k8s --format kustomize --out ./deploy/rendered
+```
+
+Output shape:
+
+```
+deploy/chart/
+├── Chart.yaml
+├── values.yaml                      # stub — real values live in Argo/Flux
+├── templates/
+│   ├── deployment-<agent>.yaml
+│   ├── service-<agent>.yaml
+│   ├── servicemonitor-<agent>.yaml   # gate with --no-servicemonitor
+│   └── secret-<agent>.yaml           # empty stub — populated by ESO / Vault
+└── README.md
+```
+
+The render is **deterministic and offline** (no `kubectl`, no network). Run it in CI on PR merge; snapshot-test the output against golden files.
+
+## Step 2 — Commit to your GitOps repo
+
+CI pushes the rendered directory to either the same repo (`deploy/` path) or a dedicated GitOps repo your Argo/Flux instance watches. Treat the render output as a **build artifact**, not a hand-edited chart — bump the chart version whenever you bump `@declaragent/cli`.
+
+## Step 3a — ArgoCD Application
+
+```yaml
+# argocd/applications/orders-fleet.yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: orders-fleet
+  namespace: argocd
+spec:
+  project: platform
+  source:
+    repoURL: https://github.com/acme/agents-gitops
+    path: fleets/orders/chart
+    targetRevision: main
+    helm:
+      valueFiles: [values-prod.yaml]
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: agents-prod
+  syncPolicy:
+    automated: { prune: true, selfHeal: true }
+    syncOptions: [CreateNamespace=true, ApplyOutOfSyncOnly=true]
+```
+
+For per-environment fan-out use an `ApplicationSet` over a Kustomize base:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata: { name: orders-fleet, namespace: argocd }
+spec:
+  generators:
+    - list:
+        elements:
+          - { env: dev,  cluster: https://dev.example }
+          - { env: prod, cluster: https://prod.example }
+  template:
+    metadata: { name: 'orders-{{env}}' }
+    spec:
+      source:
+        repoURL: https://github.com/acme/agents-gitops
+        path: fleets/orders/overlays/{{env}}
+      destination: { server: '{{cluster}}', namespace: agents }
+```
+
+## Step 3b — Flux HelmRelease
+
+```yaml
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata: { name: agents, namespace: flux-system }
+spec:
+  url: https://github.com/acme/agents-gitops
+  ref: { branch: main }
+  interval: 1m
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata: { name: orders-fleet, namespace: agents-prod }
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: ./fleets/orders/chart
+      sourceRef: { kind: GitRepository, name: agents, namespace: flux-system }
+  values:
+    replicaCount: 3
+    serviceMonitor:
+      enabled: true
+```
+
+Or swap `HelmRelease` for `Kustomization` when you rendered with `--format kustomize`.
+
+## Secrets — the non-obvious bit
+
+The rendered `Secret` has empty values by design. Wire them up with your existing reconciler:
+
+```yaml
+# ExternalSecret alongside the rendered chart
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata: { name: orders-fleet-anthropic, namespace: agents-prod }
+spec:
+  refreshInterval: 1h
+  secretStoreRef: { name: vault-prod, kind: ClusterSecretStore }
+  target: { name: orders-fleet-anthropic }
+  data:
+    - secretKey: ANTHROPIC_API_KEY
+      remoteRef: { key: agents/orders, property: anthropic_key }
+```
+
+## Verify reconciliation
+
+```bash
+# ArgoCD
+argocd app get orders-fleet --refresh
+argocd app sync orders-fleet
+
+# Flux
+flux get helmrelease orders-fleet -n agents-prod
+flux reconcile helmrelease orders-fleet -n agents-prod --with-source
+```
+
+Then confirm the audit chain is intact:
+
+```bash
+kubectl exec -n agents-prod deploy/orders-concierge -- \
+  declaragent audit verify --json
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| Argo stuck `OutOfSync` on the ServiceMonitor | Prometheus Operator not installed on this cluster | Re-render with `--no-servicemonitor`, or add `ignoreDifferences` for the CRD |
+| HelmRelease `InstallFailed: missing key ANTHROPIC_API_KEY` | ExternalSecret hasn't synced yet | `kubectl get externalsecret -A`; add a sync wave so secrets reconcile before the Deployment |
+| Pods CrashLoop with `AUTH_REJECTED` | Fleet has `rpc.auth.enabled: true` but a peer is missing an `auth:` block | See [Zero-trust RPC migration](/cookbook/zero-trust-rpc-migration) |
+
+## Related
+
+- [CLI → `declaragent fleet render`](/reference/cli).
+- [Reference → Fleet manifest](/reference/fleet).
+- [Cross-host fleet on Kafka](/cookbook/cross-host-fleet-kafka) — pair GitOps deploy with multi-host observability.
+- [Grafana dashboard import](/cookbook/grafana-dashboard-import).

--- a/docs-site/docs/cookbook/grafana-dashboard-import.mdx
+++ b/docs-site/docs/cookbook/grafana-dashboard-import.mdx
@@ -1,0 +1,133 @@
+---
+id: grafana-dashboard-import
+title: Import the Declaragent Grafana dashboard
+sidebar_label: Grafana dashboard import
+---
+
+# Import the ready-made Grafana dashboard
+
+An importable Grafana dashboard ships in the repo at [`docs/grafana/declaragent-fleet-dashboard.json`](https://github.com/declaragent/declaragent/blob/main/docs/grafana/declaragent-fleet-dashboard.json). It aggregates every Prometheus counter + gauge + histogram the runtime exports through 0.7.6 into three rows — MCP health, audit + SIEM, rate limits + dispatch — and lets you filter by `server_id` / `agent` / `source` from the top of the page.
+
+This recipe is the five-minute path from "zero dashboards" to "full fleet at a glance".
+
+## Prerequisites
+
+- Grafana ≥ 10.
+- A Prometheus data source already wired in Grafana.
+- Prometheus scraping at least one Declaragent host's `/metrics` endpoint.
+
+## Step 1 — Expose `/metrics`
+
+`declaragent up -d` binds `/metrics` on `127.0.0.1:9464` by default. Override with `DECLARAGENT_METRICS_PORT` (set to `0` to disable).
+
+To scrape from a remote Prometheus, bind to `0.0.0.0` **and** require auth (`agent.yaml#controlPlane.bind` + an OIDC/OAuth2 block — see [`/reference/control-plane`](/reference/control-plane)). Don't expose `:9464` to the internet without auth.
+
+## Step 2 — Prometheus scrape config
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: declaragent
+    static_configs:
+      - targets:
+          - declaragent-host-1:9464
+          - declaragent-host-2:9464
+          - declaragent-host-3:9464
+    metrics_path: /metrics
+    scrape_interval: 15s
+```
+
+On Kubernetes, the rendered chart emits a `ServiceMonitor` by default (gate with `declaragent fleet render --no-servicemonitor` if you don't run the Prometheus Operator) — no static config needed.
+
+OTel Collector users: point the scrape at the collector's Prometheus exporter port (`:9464` by convention), not every CLI host.
+
+## Step 3 — Import
+
+### Grafana UI
+
+1. Dashboards → Import → Upload JSON file.
+2. Pick `docs/grafana/declaragent-fleet-dashboard.json`.
+3. Select your Prometheus data source when prompted for `DS_PROMETHEUS`.
+4. Dashboard lands under the `declaragent` tag.
+
+### Grafana HTTP API
+
+```bash
+curl -X POST http://admin:admin@grafana:3000/api/dashboards/db \
+  -H 'Content-Type: application/json' \
+  -d "$(jq '{
+    dashboard: .,
+    overwrite: true,
+    inputs: [{"name":"DS_PROMETHEUS","type":"datasource","pluginId":"prometheus","value":"Prometheus"}]
+  }' docs/grafana/declaragent-fleet-dashboard.json)"
+```
+
+### grafana-operator ConfigMap (GitOps)
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: declaragent-fleet-dashboard
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+data:
+  declaragent.json: |-
+    # contents of docs/grafana/declaragent-fleet-dashboard.json
+```
+
+Commit this alongside the [rendered chart](/cookbook/gitops-argocd-flux) and ArgoCD / Flux reconciles both.
+
+## What the three rows show
+
+| Row | Signal | Panels |
+| --- | --- | --- |
+| **1 · MCP health** | Supervisor restarts, drain duration, circuit state, rate-limit rejects | `mcp_server_restarts_total`, `mcp_server_circuit_state`, `mcp_server_circuit_open_total`, `mcp_server_drain_duration_ms`, `mcp_server_rate_limited_total` |
+| **2 · Audit + SIEM** | Back-pressure active/paused, adaptive batch interval, export throughput, chain lag | `declaragent_audit_backpressure_{active,paused_total,backlog_ms}`, `declaragent_audit_batch_{interval_ms,rows}`, `declaragent_audit_export_{acked_total,failures_total,last_seq}` |
+| **3 · Rate limits + dispatch** | Provider + per-tool waits, source throughput, DLQ depth | `declaragent_provider_rate_limit_{waits,wait_ms}`, `declaragent_tool_rate_limit_waits_total`, `source_messages_{received,processed,dlq}`, `source_inflight` |
+
+## Recommended alerts
+
+Wire these in your alertmanager stack. Thresholds are starting points — tune to your SLO.
+
+```yaml
+groups:
+  - name: declaragent
+    rules:
+      - alert: DeclaragentSiemBackpressure
+        expr: rate(declaragent_audit_backpressure_paused_total[5m]) > 0
+        for: 5m
+        labels: { severity: warning }
+        annotations:
+          summary: "SIEM export falling behind on {{ $labels.instance }}"
+          runbook: "https://docs.declaragent.dev/cookbook/siem-audit-export"
+
+      - alert: DeclaragentMcpCircuitOpen
+        expr: sum by (server_id) (mcp_server_circuit_state) > 0
+        for: 2m
+        labels: { severity: critical }
+
+      - alert: DeclaragentDispatchDlqGrowing
+        expr: rate(source_messages_dlq_total{kind="dispatch"}[10m]) > 0
+        for: 10m
+        labels: { severity: warning }
+
+      - alert: DeclaragentToolRateLimitChoked
+        expr: rate(declaragent_tool_rate_limit_waits_total[5m]) > 10
+        for: 10m
+        labels: { severity: warning }
+        annotations:
+          summary: "Tool {{ $labels.tool }} repeatedly rate-limited"
+```
+
+## Distributed tracing
+
+The same counters flow through OTel when `OTEL_EXPORTER_OTLP_ENDPOINT` is set — see [Trace a request in Grafana](/cookbook/grafana-tracing) for the end-to-end span recipe that pairs with this dashboard.
+
+## Related
+
+- [Dashboard bundle README](https://github.com/declaragent/declaragent/blob/main/docs/grafana/README.md).
+- [Reference → Observability](/reference/observability).
+- [SIEM audit export](/cookbook/siem-audit-export).
+- [Cross-host fleet on Kafka](/cookbook/cross-host-fleet-kafka).

--- a/docs-site/docs/cookbook/index.mdx
+++ b/docs-site/docs/cookbook/index.mdx
@@ -36,6 +36,18 @@ Cross-cutting how-tos built on top of the runtime.
 | [Run two tenants on one daemon](/cookbook/two-tenants-one-daemon) | Isolated state, extensions, and quotas — one process. |
 | [Trace a request in Grafana](/cookbook/grafana-tracing) | End-to-end OTel span from inbound → engine → outbound. |
 
+## Enterprise recipes
+
+Platform / SRE / security paths — built on features enterprise buyers ask about first.
+
+| Recipe | Goal |
+| --- | --- |
+| [GitOps deploy with ArgoCD or Flux](/cookbook/gitops-argocd-flux) | `fleet render` → git → your existing Argo/Flux reconciler. Drift detection + rollback for free. |
+| [Stream audit to Splunk / Elastic / Datadog](/cookbook/siem-audit-export) | Hash-chained audit into your SIEM with back-pressure + adaptive batch. |
+| [Zero-trust RPC migration (0.8.0)](/cookbook/zero-trust-rpc-migration) | Pre-flight `fleet audit-rpc --strict` in CI before the default flip. |
+| [Cross-host fleet on Kafka](/cookbook/cross-host-fleet-kafka) | Split a fleet across regions; observe it as one with `hosts[]` fan-out. |
+| [Import the Grafana dashboard](/cookbook/grafana-dashboard-import) | Three-row importable dashboard covering MCP, audit, rate limits. |
+
 ## Missing something?
 
 Open a discussion at [github.com/declaragent/declaragent/discussions](https://github.com/declaragent/declaragent/discussions) — cookbook pages are the quickest way to ship knowledge back to the community.

--- a/docs-site/docs/cookbook/siem-audit-export.mdx
+++ b/docs-site/docs/cookbook/siem-audit-export.mdx
@@ -1,0 +1,129 @@
+---
+id: siem-audit-export
+title: Stream audit to Splunk, Elastic, or Datadog
+sidebar_label: SIEM audit export
+---
+
+# Stream the audit chain to your SIEM
+
+Every tool call, channel event, secret read, and policy decision Declaragent makes lands in a **hash-chained** audit log — each row carries a SHA-256 of the previous row, so tampering is detectable with `declaragent audit verify`. This recipe streams that same chain to Splunk HEC, Elastic bulk, or Datadog Logs v2 so your SOC can alert on it alongside everything else.
+
+Three features the `agent.yaml#audit.export` loop ships by default:
+
+- **Back-pressure** — when the exporter falls behind, the daemon slows the ingress side instead of silently dropping events (`audit_backpressure_paused_total`).
+- **Adaptive batch interval** — the loop widens `intervalMs` under steady load and collapses it back when the queue drains (`audit_batch_interval_ms`).
+- **Cursor persistence** — restart the daemon and the exporter resumes from the last ack'd `seq` (stored in the `audit_export_cursor` SQLite table).
+
+## Prerequisites
+
+- `@declaragent/cli ≥ 0.7.4`.
+- SIEM credentials in an env var or a secret resolver (`${secret:vault:…}`). **Never** inline a token in `agent.yaml`.
+- Network egress from the daemon host to the SIEM endpoint. For hardened envs, front it with a forward proxy and set `HTTPS_PROXY`.
+
+## Splunk HEC
+
+```yaml
+# agent.yaml
+id: orders-concierge
+audit:
+  export:
+    kind: splunk
+    hecUrl: https://http-inputs-acme.splunkcloud.com/services/collector/event
+    token: env:SPLUNK_HEC_TOKEN
+    index: declaragent_prod
+    sourcetype: declaragent:audit
+    batchSize: 200
+    intervalMs: 5000
+```
+
+Verify in Splunk:
+
+```
+index=declaragent_prod sourcetype="declaragent:audit"
+| head 10
+| table _time, kind, tenantId, recordHash, prevHash
+```
+
+## Elastic bulk
+
+```yaml
+audit:
+  export:
+    kind: elastic
+    baseUrl: https://es.acme.internal:9200
+    index: declaragent-audit
+    auth:
+      kind: apiKey
+      apiKey: env:ELASTIC_API_KEY
+```
+
+Supported auth modes: `apiKey`, `basic` (username + password), `bearer` (see `packages/core/src/agents/load-agent.ts:370`).
+
+## Datadog Logs v2
+
+```yaml
+audit:
+  export:
+    kind: datadog
+    apiKey: env:DATADOG_API_KEY
+    site: datadoghq.eu                 # or datadoghq.com / us3 / us5 / ap1
+    service: declaragent
+    source: declaragent:audit
+    tags: env:prod,team:platform
+```
+
+## Verify the chain inside the SIEM
+
+Each exported row carries `recordHash` + `prevHash`. Your SIEM can re-run the chain check without hitting Declaragent:
+
+```splunk
+| sort _time
+| streamstats current=f last(recordHash) as expected_prev by tenantId
+| where expected_prev != prevHash AND isnotnull(expected_prev)
+| stats count by tenantId
+```
+
+Any non-zero row = tampering (or an exporter bug). Wire that as a Splunk/Elastic/Datadog alert into your existing SOC rotation.
+
+## Metrics you should alert on
+
+All three shipped via the Prometheus registry (see the [Grafana dashboard](/cookbook/grafana-dashboard-import) row 2):
+
+| Metric | Alert when |
+| --- | --- |
+| `declaragent_audit_backpressure_paused_total` | Rate > 0 sustained for 5 min — SIEM is slow, ingress is being throttled |
+| `declaragent_audit_export_failures_total{retryable="false"}` | Any increment — permanent SIEM failure (bad token, schema reject) |
+| `declaragent_audit_batch_interval_ms` | Stuck at max — loop is in emergency widen mode |
+| `declaragent_audit_export_last_seq` lag vs `declaragent_audit_last_seq` | Gap > 10k — exporter cursor drifting; check SIEM health |
+
+## Multi-tenant
+
+Every exported row carries `tenantId` (`"_system"` for chain-wide entries). Filter at SIEM ingest, or route per-tenant to separate indices:
+
+```yaml
+audit:
+  export:
+    kind: splunk
+    hecUrl: …
+    token: env:SPLUNK_HEC_TOKEN
+    # index is set per-tenant at runtime via ${tenant:id}
+    index: "declaragent_${tenant:id}"
+```
+
+Combine with the [Multi-tenant starter](/cookbook/multi-tenant-starter) for full isolation.
+
+## Failure modes
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| Loop paused, `audit_export_failures_total` climbing | 5 consecutive non-retryable failures — loop self-paused | Check exporter config; rows resume on next restart after fix |
+| `401 invalid token` on Splunk | HEC token rotated out-of-band | Rotate via [`declaragent secrets rotate`](/cookbook/rotate-vault-secret); no restart needed |
+| SIEM sees duplicate rows after crash | Exporter ack'd the POST but lost cursor commit | Idempotent — dedupe on `seq` or `recordHash` at SIEM ingest |
+| Back-pressure stuck ON | SIEM is healthy but network egress throttled | Check `HTTPS_PROXY`; widen `batchSize` (fewer round-trips) |
+
+## Related
+
+- [CLI → `declaragent audit`](/reference/cli).
+- [Reference → Observability](/reference/observability).
+- [Grafana dashboard import](/cookbook/grafana-dashboard-import) — SIEM + back-pressure panels pre-wired.
+- Source: `packages/core/src/audit/exporters/{splunk,elastic,datadog}.ts`.

--- a/docs-site/docs/cookbook/zero-trust-rpc-migration.mdx
+++ b/docs-site/docs/cookbook/zero-trust-rpc-migration.mdx
@@ -133,5 +133,5 @@ This is a **compatibility knob, not a supported long-term mode**. Set a reminder
 
 - [Migration plan doc](https://github.com/declaragent/declaragent/blob/main/docs/ZERO_TRUST_DEFAULT_MIGRATION.md).
 - [Reference → RPC](/reference/rpc).
-- [Per-agent `AuthVerifyRegistry`](/reference/rpc#auth-verify-registry).
+- [Per-agent `AuthVerifyRegistry`](/reference/rpc).
 - [CLI → `declaragent fleet audit-rpc`](/reference/cli).

--- a/docs-site/docs/cookbook/zero-trust-rpc-migration.mdx
+++ b/docs-site/docs/cookbook/zero-trust-rpc-migration.mdx
@@ -1,0 +1,137 @@
+---
+id: zero-trust-rpc-migration
+title: Zero-trust RPC migration (0.7.x → 0.8.0)
+sidebar_label: Zero-trust RPC migration
+---
+
+# Prepare your fleet for the 0.8.0 zero-trust default
+
+At **0.8.0**, `rpc.auth.enabled` flips to `true` by default whenever `rpc-peers.yaml` is present. Fleets with a peer that lacks an `auth:` block will fail boot with `AUTH_REJECTED`. The full migration plan is at [`docs/ZERO_TRUST_DEFAULT_MIGRATION.md`](https://github.com/declaragent/declaragent/blob/main/docs/ZERO_TRUST_DEFAULT_MIGRATION.md) — this recipe is the operational walkthrough.
+
+**Recommendation:** run `--strict` in CI for 2–3 weeks before taking 0.8.0.
+
+## The pre-flight inspector
+
+```bash
+declaragent fleet audit-rpc               # report only
+declaragent fleet audit-rpc --suggest-enable   # report + copy-pasteable YAML diffs
+declaragent fleet audit-rpc --strict           # exit 1 on any gap — wire into CI
+declaragent fleet audit-rpc --json             # machine-readable, pipe to jq
+```
+
+Shipped at 0.7.3 (`packages/cli/src/fleet-audit-rpc-cli.ts`). Safe to run in any environment — no network IO, no state mutation.
+
+## Step 1 — Baseline audit
+
+From the fleet root:
+
+```bash
+declaragent fleet audit-rpc --json | jq '.findings[]'
+```
+
+Each finding categorises a peer:
+
+- `OK` — has an `auth:` block today, no action needed.
+- `MISSING_AUTH` — peer will fail boot at 0.8.0.
+- `MISSING_PEERS_FILE` — agent declares peers but no `rpc-peers.yaml` exists.
+- `INVALID_PROVIDER` — `auth.provider` doesn't match the peer's declared provider.
+
+## Step 2 — Apply the suggested diff
+
+```bash
+declaragent fleet audit-rpc --suggest-enable
+```
+
+Example output (each gap is pre-filled with the peer's declared provider):
+
+```yaml
+# agents/concierge/rpc-peers.yaml
+peers:
+  - id: pr-reviewer
+    transport: kafka
+    topic: agents.pr-reviewer.inbound
++   auth:
++     enabled: true
++     provider: hs256                     # from peer's declared provider
++     secret: env:AGENT_RPC_SHARED_SECRET
++     audience: pr-reviewer
++     issuer: concierge
+```
+
+Paste the blocks into each `rpc-peers.yaml`. Common auth providers:
+
+| Provider | When to use | Secret ref |
+| --- | --- | --- |
+| `hs256` | Shared secret between trusted peers | `env:…` or `${secret:vault:…}` |
+| `rs256` | Peers in different trust domains | JWKS URL |
+| `oidc` | Peers mediated by your IdP | Issuer + audience |
+
+## Step 3 — Validate
+
+```bash
+declaragent fleet validate
+declaragent fleet audit-rpc --strict        # must exit 0
+```
+
+## Step 4 — Wire `--strict` into CI
+
+Add to `.github/workflows/ci.yml` (or your equivalent):
+
+```yaml
+- name: Zero-trust RPC audit (will be required at 0.8.0)
+  run: |
+    bunx @declaragent/cli fleet audit-rpc --strict
+```
+
+Run this for **at least 2–3 weeks** before upgrading to 0.8.0. It catches PRs that add a peer without auth before they land.
+
+## Step 5 — Flip the default locally (dry-run)
+
+Before 0.8.0 ships, you can opt-in early:
+
+```yaml
+# fleet.yaml
+rpc:
+  auth:
+    enabled: true                  # opt-in to the 0.8.0 default today
+```
+
+Re-run your soak tests. If a peer still boots with `AUTH_REJECTED`, the inspector missed something — please open an issue with the `--json` output.
+
+## Step 6 — Upgrade to 0.8.0
+
+Once CI has been green on `--strict` for 2+ weeks:
+
+```bash
+bun add -D @declaragent/cli@^0.8
+declaragent fleet validate
+declaragent fleet up -d
+```
+
+Fleets that skipped the pre-flight will see this at boot:
+
+```
+✗ AUTH_REJECTED: peer "pr-reviewer" on agent "concierge" has no `auth:` block.
+  Since 0.8.0, `rpc.auth.enabled` defaults to true when rpc-peers.yaml is present.
+  Remediation: run `declaragent fleet audit-rpc --suggest-enable` and paste
+  the generated auth block into agents/concierge/rpc-peers.yaml.
+```
+
+## Rollback
+
+If you need to delay the flip (e.g. mid-incident), opt back out temporarily:
+
+```yaml
+rpc:
+  auth:
+    enabled: false                 # temporary — re-enable before end of sprint
+```
+
+This is a **compatibility knob, not a supported long-term mode**. Set a reminder; `rpc.auth.enabled: false` will be removed in a future minor.
+
+## Related
+
+- [Migration plan doc](https://github.com/declaragent/declaragent/blob/main/docs/ZERO_TRUST_DEFAULT_MIGRATION.md).
+- [Reference → RPC](/reference/rpc).
+- [Per-agent `AuthVerifyRegistry`](/reference/rpc#auth-verify-registry).
+- [CLI → `declaragent fleet audit-rpc`](/reference/cli).

--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -64,6 +64,17 @@ const sidebars: SidebarsConfig = {
             'cookbook/grafana-tracing',
           ],
         },
+        {
+          type: 'category',
+          label: 'Enterprise',
+          items: [
+            'cookbook/gitops-argocd-flux',
+            'cookbook/siem-audit-export',
+            'cookbook/zero-trust-rpc-migration',
+            'cookbook/cross-host-fleet-kafka',
+            'cookbook/grafana-dashboard-import',
+          ],
+        },
       ],
     },
   ],


### PR DESCRIPTION
## Summary

Adds five recipe MDX pages aimed at enterprise-buyer evaluation paths, each cross-linked from the cookbook index and wired into a new **Enterprise** sidebar category.

| Recipe | Enterprise angle |
| --- | --- |
| `gitops-argocd-flux` | \`fleet render\` → git → ArgoCD or Flux reconciler |
| `siem-audit-export` | Hash-chained audit → Splunk / Elastic / Datadog with back-pressure |
| `zero-trust-rpc-migration` | \`fleet audit-rpc --strict\` pre-flight for the 0.8.0 default flip |
| `cross-host-fleet-kafka` | \`fleet.yaml#hosts[]\` fan-out + cross-host DLQ mutations |
| `grafana-dashboard-import` | The shipped dashboard JSON + ready-to-paste alertmanager rules |

Cherry-picked from \`release/cli-0.7.6\` (commit \`733fad2\`) plus a follow-up that fixes a broken anchor caught by the local docusaurus build.

## Verification

- \`cd docs-site && npm run build\` clean (the only warning is the pre-existing upstream \`vscode-languageserver-types\` dependency notice).
- Live preview deployed to Cloudflare Pages on the source branch:
  - https://release-cli-0-7-6.declaragent-docs.pages.dev/cookbook
- Every CLI flag, env var, config key, and metric name was verified against source: \`fleet-render-cli.ts\`, \`fleet-audit-rpc-cli.ts\`, \`fleet-cross-host-cli.ts\`, \`audit/exporters/exporter.ts\`, \`docs/grafana/README.md\`.

## Test plan

- [ ] Reviewer skims the 5 new pages for tone + accuracy
- [ ] CI \`docs-site\` workflow green (PR-gate \`npm run build\`)
- [ ] On merge: existing \`Deploy to Cloudflare Pages\` job publishes to declaragent.dev
- [ ] Sidebar shows new "Enterprise" category under Cookbook
- [ ] No new broken-anchor warnings vs. main

## Notes

- Pure docs change. No code under \`packages/\` touched.
- The new "Enterprise" category sits alongside existing "Templates" and "Recipes" categories — keeps enterprise-focused content discoverable without burying it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)