### PR TITLE
fix(ci): biome-format package.json after changesets bump

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,11 +13,7 @@
       "import": "./dist/index.js"
     }
   },
-  "files": [
-    "dist",
-    "README.md",
-    "LICENSE"
-  ],
+  "files": ["dist", "README.md", "LICENSE"],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit",

--- a/packages/testkit/package.json
+++ b/packages/testkit/package.json
@@ -21,11 +21,7 @@
       "import": "./dist/channels/index.js"
     }
   },
-  "files": [
-    "dist",
-    "README.md",
-    "LICENSE"
-  ],
+  "files": ["dist", "README.md", "LICENSE"],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",


### PR DESCRIPTION
`main` is red on **Lint** since the 0.7.6 release (#115): `changesets version` re-serialized `packages/core/package.json` and `packages/testkit/package.json` with a multi-line `files` array that Biome 1.9.4 wants single-line.

This re-formats both (no functional change). `biome check .` is clean afterward.

The npm-install-smoke failures are the separate pre-existing #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)