### PR TITLE
fix(ci): unbreak npm-install-smoke pack step (#114)

### DIFF
--- a/.github/workflows/npm-install-smoke.yml
+++ b/.github/workflows/npm-install-smoke.yml
@@ -114,7 +114,12 @@ jobs:
           npm pack --dry-run 2>&1 | tee /tmp/npm-pack-dryrun.log
           grep -q 'bin/declaragent.js' /tmp/npm-pack-dryrun.log
           grep -q 'bin/postinstall.js' /tmp/npm-pack-dryrun.log
-          TGZ="$(npm pack --silent)"
+          # `prepack` (copy-templates) prints to stdout, so the tarball
+          # name is the trailing `.tgz` line, not the whole capture.
+          TGZ="$(npm pack --silent | grep -E '\.tgz$' | tail -n1)"
+          if [ -z "${TGZ}" ] || [ ! -f "${TGZ}" ]; then
+            echo "::error::npm pack did not produce a tarball (got '${TGZ}')." >&2; exit 1
+          fi
           echo "tgz=${PWD}/${TGZ}" >> "${GITHUB_OUTPUT}"
 
       - name: Install globally


### PR DESCRIPTION
The P0-2 `copy-templates` prepack pollutes `npm pack --silent` stdout, so the "Pack npm tarball" step's `$TGZ` capture broke `$GITHUB_OUTPUT` on every npm-install-smoke run (macos + ubuntu). Capture the trailing `.tgz` line instead — same fix as npm-pack-and-run.yml. Makes `main` fully green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)