### PR TITLE
redesign(website): honest, consolidated marketing homepage

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -3,17 +3,17 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Declaragent — the declarative runtime for AI agent fleets</title>
+    <title>Declaragent — declarative, git-versioned AI agents</title>
     <meta
       name="description"
-      content="One agent.yaml. git log. Production. Declaragent is the declarative runtime for AI agent fleets — Prometheus, OpenTelemetry, audit chain, circuit breakers, rate limits, canary deploys, all in the box. Open source. Evidence-based honest status for every capability."
+      content="One agent.yaml in your repo. git log as the source of truth. Declaragent is an open-source declarative runtime for AI agents — tools, skills, channels, audit, metrics and permissions, all declared. Every capability publicly graded ✓ shipped / ◐ partial / ○ tracked."
     />
 
     <!-- Open Graph / social -->
-    <meta property="og:title" content="Declaragent — the declarative runtime for AI agent fleets" />
+    <meta property="og:title" content="Declaragent — declarative, git-versioned AI agents" />
     <meta
       property="og:description"
-      content="One agent.yaml. git log. Production. Audit chain, Prometheus, OTel, circuit breakers, canary deploys — in the box. Every capability publicly graded ✓ shipped / ◐ partial / ○ tracked."
+      content="One agent.yaml. git log. Your agent's identity, tools, channels, permissions and deploy — declared in your repo. Open source, 0.x, every capability graded ✓ / ◐ / ○ with evidence."
     />
     <meta property="og:url" content="https://declaragent.dev" />
     <meta property="og:type" content="website" />
@@ -24,7 +24,7 @@
     <meta name="twitter:title" content="Declaragent" />
     <meta
       name="twitter:description"
-      content="The declarative runtime for AI agent fleets. One agent.yaml. git log. Production. Every capability graded ✓ / ◐ / ○ with file:line evidence."
+      content="Declarative, git-versioned AI agents. One agent.yaml. git log. Every capability graded ✓ / ◐ / ○ with file:line evidence. Open source."
     />
     <meta name="twitter:image" content="https://declaragent.dev/og.svg" />
 
@@ -40,27 +40,25 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Inter:wght@400;500;600;700;800&display=swap"
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700;800&family=Inter:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="/styles.css?v=6" />
+    <link rel="stylesheet" href="/styles.css?v=7" />
 
-    <!-- JSON-LD structured data — SoftwareApplication + Organization.
-         Search engines use this for rich results; Slack/Discord/LinkedIn
-         unfurls fall back on og:* above. -->
+    <!-- JSON-LD structured data — SoftwareApplication + Organization. -->
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "SoftwareApplication",
         "name": "Declaragent",
         "alternateName": "d9t",
-        "description": "The declarative runtime for AI agent fleets. One agent.yaml, git-versioned, with audit chain, Prometheus, OpenTelemetry, circuit breakers, rate limits and canary deploys in the box.",
+        "description": "Open-source declarative runtime for AI agents. One agent.yaml, git-versioned, with a hash-chained audit log, Prometheus metrics, OpenTelemetry traces, circuit breakers, rate limits and a permission gate — all declared in your repo.",
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "macOS, Linux, Windows (WSL)",
         "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
         "url": "https://declaragent.dev",
         "downloadUrl": "https://www.npmjs.com/package/@declaragent/cli",
-        "softwareVersion": "0.7.1",
+        "softwareVersion": "0.7.6",
         "license": "https://github.com/declaragent/declaragent/blob/main/LICENSE",
         "author": {
           "@type": "Organization",
@@ -75,10 +73,7 @@
       }
     </script>
 
-    <!-- Analytics — PostHog (product analytics + session replay +
-         funnels + feature flags).
-         The `track()` helper in app.js routes `data-track` clicks
-         through `posthog.capture`. EU hosting: eu.i.posthog.com. -->
+    <!-- Analytics — PostHog (EU-hosted). track() in app.js routes data-track clicks. -->
     <script>
       !(function (t, e) {
         var o, n, p, r;
@@ -133,33 +128,23 @@
   </head>
 
   <body>
+    <div class="grain" aria-hidden="true"></div>
+
     <!-- ───── HEADER ───── -->
     <header class="site-header">
       <a href="/" class="brand" aria-label="Declaragent home">
-        <svg viewBox="0 0 32 32" width="28" height="28" aria-hidden="true">
-          <rect x="2" y="2" width="28" height="28" rx="6" fill="var(--accent)" />
-          <text
-            x="16"
-            y="22"
-            text-anchor="middle"
-            font-family="JetBrains Mono, monospace"
-            font-weight="700"
-            font-size="18"
-            fill="var(--bg)"
-          >
-            d
-          </text>
+        <svg viewBox="0 0 32 32" width="26" height="26" aria-hidden="true" class="brand__mark">
+          <rect x="2" y="2" width="28" height="28" rx="7" fill="var(--accent)" />
+          <text x="16" y="22" text-anchor="middle" font-family="JetBrains Mono, monospace" font-weight="800" font-size="18" fill="var(--bg)">d</text>
         </svg>
-        <span>declaragent</span>
-        <span class="brand__alias" title="Short-form CLI alias. Same binary, same everything.">
-          <span class="brand__alias-dot">·</span>d9t
-        </span>
+        <span class="brand__name">declaragent</span>
+        <span class="brand__alias" title="Short-form CLI alias. Same binary, same everything.">d9t</span>
       </a>
       <nav class="site-nav" aria-label="Primary">
-        <a href="https://docs.declaragent.dev" target="_blank" rel="noopener" data-track="nav:docs">Docs</a>
+        <a href="#how" data-track="nav:how">How it works</a>
         <a href="#capabilities" data-track="nav:capabilities">Capabilities</a>
-        <a href="#honest-status" data-track="nav:status">Status</a>
-        <a href="https://www.npmjs.com/org/declaragent" target="_blank" rel="noopener" data-track="nav:npm">npm</a>
+        <a href="#status" data-track="nav:status">Honest status</a>
+        <a href="https://docs.declaragent.dev" target="_blank" rel="noopener" data-track="nav:docs">Docs</a>
         <a
           class="star-pill"
           href="https://github.com/declaragent/declaragent"
@@ -168,1275 +153,292 @@
           data-track="nav:star"
           aria-label="Star Declaragent on GitHub"
         >
-          <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
-            <path
-              fill="currentColor"
-              d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.72 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"
-            />
+          <svg viewBox="0 0 16 16" width="13" height="13" aria-hidden="true">
+            <path fill="currentColor" d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.72 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z" />
           </svg>
           <span>Star</span>
-          <span class="star-pill__divider" aria-hidden="true">·</span>
-          <span class="star-pill__label">GitHub</span>
         </a>
       </nav>
     </header>
 
     <main>
-      <!-- ───── HERO ─────
-           Single H1, single lede ≤ 30 words, one primary action (copy
-           install), one secondary (star). Everything else descopes. -->
-      <section class="hero">
+      <!-- ───── HERO ───── -->
+      <section class="hero" id="top">
         <div class="hero__copy">
-          <p class="eyebrow">
-            <span class="eyebrow__pill">v0.7.1</span>
-            <span class="eyebrow__sep">·</span>
-            <span>shipped 2026-04-23</span>
-            <span class="eyebrow__sep">·</span>
-            <a
-              class="eyebrow__link"
-              href="https://github.com/declaragent/declaragent/blob/main/packages/cli/CHANGELOG.md"
-              target="_blank"
-              rel="noopener"
-              data-track="hero:release-notes"
-              >release notes ↗</a
-            >
-          </p>
+          <p class="kicker"><span class="kicker__sq"></span>open source · apache-2.0 · v0.7.6 on npm</p>
           <h1>
-            Stop shipping agent <span class="strike">prototypes</span>.<br />
-            <span class="accent">Ship an <code class="h1-code">agent.yaml</code>.</span>
+            Stop shipping agent<br />prototypes.<br />
+            <span class="hero__accent">Ship an <code>agent.yaml</code>.</span>
           </h1>
-          <p class="lede">
-            The declarative runtime for AI agent fleets. Write
-            <code>agent.yaml</code>. Commit it. Run <code>declaragent up</code>.
-            Prometheus, OpenTelemetry, audit chain, circuit breakers, canary
-            deploys — in the box.
+          <p class="hero__sub">
+            Declaragent is a declarative, git-versioned runtime for AI agents. Your agent's
+            identity, tools, skills, channels, permissions, secrets and deploy live in one
+            <code>agent.yaml</code> in your repo — <span class="nowrap">no hidden console,</span>
+            no vendor dashboard. <code>git log</code> is the source of truth.
           </p>
-          <div class="hero__actions">
-            <code
-              class="cmd"
+
+          <div class="install">
+            <div class="install__tabs" role="tablist" aria-label="Install method">
+              <button class="install__tab is-active" role="tab" aria-selected="true" data-install="npm" data-track="install:tab-npm">npm</button>
+              <button class="install__tab" role="tab" aria-selected="false" data-install="brew" data-track="install:tab-brew">brew</button>
+              <button class="install__tab" role="tab" aria-selected="false" data-install="curl" data-track="install:tab-curl">curl</button>
+            </div>
+            <button
               id="install-cmd"
-              role="button"
-              tabindex="0"
-              data-track="hero:copy-install"
+              class="install__cmd"
+              type="button"
               aria-label="Copy install command"
-              ><span class="cmd__prompt">$</span> npm i -g
-              @declaragent/cli<span class="cmd__copy" aria-hidden="true">⎘</span></code
+              data-track="install:copy"
             >
-            <a
-              class="btn btn--ghost star-btn"
-              href="https://github.com/declaragent/declaragent"
-              target="_blank"
-              rel="noopener"
-              data-track="hero:star"
-            >
-              <svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
-                <path
-                  fill="currentColor"
-                  d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.72 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"
-                />
-              </svg>
-              <span>Star on GitHub</span>
-            </a>
-          </div>
-
-          <!-- Stat row — receipts-first design: every claim, a pill.
-               Updated 2026-04-23 to reflect 0.7.1 shipping the full
-               enterprise stack. Each receipt in the rail below links
-               to the public PR. -->
-          <ul class="stat-row" role="list">
-            <li class="stat">
-              <span class="stat__value">13</span>
-              <span class="stat__label">npm packages</span>
-            </li>
-            <li class="stat">
-              <span class="stat__value">8</span>
-              <span class="stat__label">built-in tools</span>
-            </li>
-            <li class="stat">
-              <span class="stat__value">
-                12/12
-                <span class="stat__mark stat__mark--ok" aria-label="shipped">✓</span>
+              <span class="install__prompt">$</span>
+              <span class="install__panels">
+                <span data-install-panel="npm" class="is-active">npm i -g @declaragent/cli</span>
+                <span data-install-panel="brew" hidden>brew install declaragent/tap/declaragent</span>
+                <span data-install-panel="curl" hidden>curl -fsSL declaragent.dev/install.sh | sh</span>
               </span>
-              <span class="stat__label">enterprise items shipped</span>
-            </li>
-          </ul>
-
-          <p class="hero__short">
-            <span class="brand__alias-inline">tip</span> short-form CLI —
-            <code>d9t up</code> runs the same as <code>declaragent up</code>.
-          </p>
+              <span class="install__copy" aria-hidden="true">copy</span>
+            </button>
+            <p class="hero__meta">
+              <span class="dot dot--ok"></span> single-machine production-ready
+              &nbsp;·&nbsp; <span class="dot dot--warn"></span> enterprise primitives in preview
+              &nbsp;·&nbsp; seeking first adopters
+            </p>
+          </div>
         </div>
 
-        <!-- Typing terminal — real CLI lifecycle. Skip button lets
-             returning visitors jump to the last frame. -->
-        <div class="hero__terminal">
-          <div class="term">
-            <div class="term__chrome">
-              <span class="term__dot term__dot--r"></span>
-              <span class="term__dot term__dot--y"></span>
-              <span class="term__dot term__dot--g"></span>
-              <span class="term__title">~/my-agent — declaragent</span>
-              <button
-                class="term__skip"
-                type="button"
-                id="term-skip"
-                data-track="hero:skip-terminal"
-                aria-label="Skip animation"
-              >
-                skip ↦
-              </button>
-            </div>
-            <pre class="term__body"><code id="term-body"></code><span class="term__cursor" id="term-cursor">█</span></pre>
+        <!-- Live typing terminal (animation in app.js) -->
+        <div class="terminal" aria-label="Declaragent CLI demo">
+          <div class="terminal__bar">
+            <span class="terminal__dots"><i></i><i></i><i></i></span>
+            <span class="terminal__title">declaragent — zsh</span>
+            <button id="term-skip" class="terminal__skip" type="button" hidden>skip ▸</button>
           </div>
+          <pre class="terminal__screen"><code id="term-body"></code><span id="term-cursor" class="terminal__cursor">▋</span></pre>
         </div>
       </section>
 
-      <!-- ───── INSTALL (moved up) ─────
-           First thing after the hero. Reduce friction to the first command.
-           Default tab is npm (hash-verified, what devs already trust). -->
-      <section class="install" id="install">
-        <div class="install__inner">
-          <h2>Install in one command.</h2>
-
-          <div class="install__tabs" role="tablist" aria-label="Install method">
-            <button
-              class="install__tab is-active"
-              type="button"
-              data-install="npm"
-              role="tab"
-              aria-selected="true"
-              data-track="install:tab:npm"
-            >
-              npm
-            </button>
-            <button
-              class="install__tab"
-              type="button"
-              data-install="brew"
-              role="tab"
-              aria-selected="false"
-              data-track="install:tab:brew"
-            >
-              brew
-            </button>
-            <button
-              class="install__tab"
-              type="button"
-              data-install="curl"
-              role="tab"
-              aria-selected="false"
-              data-track="install:tab:curl"
-            >
-              curl
-            </button>
-          </div>
-
-          <pre
-            class="install__block"
-            id="install-npm"
-            data-install-panel="npm"
-          ><code>npm i -g @declaragent/cli</code></pre>
-
-          <pre
-            class="install__block"
-            id="install-brew"
-            data-install-panel="brew"
-            hidden
-          ><code>brew tap declaragent/tap
-brew install declaragent</code></pre>
-
-          <pre
-            class="install__block"
-            id="install-curl"
-            data-install-panel="curl"
-            hidden
-          ><code>curl -fsSL https://declaragent.dev/install.sh | sh</code></pre>
-
-          <p class="install__then">Then — converse your fleet into existence:</p>
-          <pre class="install__block install__block--sub"><code>declaragent init --fleet acme
-cd acme
-DECLARAGENT_BUILDER=on declaragent     <span class="dim"># short: d9t</span></code></pre>
-          <p class="install__then install__then--thin">
-            New to Declaragent?
-            <a
-              href="https://docs.declaragent.dev/quickstart/conversational-tour"
-              target="_blank"
-              rel="noopener"
-              data-track="install:tour"
-            >
-              Take the 15-minute conversational tour →
-            </a>
-          </p>
-
-          <div class="install__links">
-            <a
-              class="btn btn--accent"
-              href="https://docs.declaragent.dev"
-              target="_blank"
-              rel="noopener"
-              data-track="install:docs"
-              >Read the docs →</a
-            >
-            <a
-              class="btn btn--ghost"
-              href="https://github.com/declaragent/declaragent"
-              target="_blank"
-              rel="noopener"
-              data-track="install:source"
-              >Source on GitHub</a
-            >
-          </div>
-        </div>
-      </section>
-
-      <!-- ───── BUILDER ─────
-           The headline differentiating feature. Front-loaded. -->
-      <section class="meta" aria-labelledby="build-title" id="build">
-        <div class="meta__inner">
-          <p class="eyebrow">Converse → fleet</p>
-          <h2 id="build-title">
-            Describe what you need. Review the plan. <span class="accent">Apply.</span>
-          </h2>
-          <p class="lede lede--muted">
-            Start the REPL with <code>DECLARAGENT_BUILDER=on declaragent</code>.
-            Tell it what the fleet should do. It proposes a complete change-set —
-            <code>agent.yaml</code>, skills, event sources, channel bindings, peer
-            entries. You review, <code>/yes</code> to apply or <code>/edit</code> to
-            adjust. Every apply is git-rollback-safe and recorded to the
-            hash-chained audit log.
-          </p>
-          <div class="meta__flow" aria-label="Conversation to deployed fleet">
-            <div class="meta__node meta__node--agent">
-              <span class="meta__node-tag">01</span>
-              <span class="meta__node-title">Describe</span>
-              <span class="meta__node-sub"
-                >"Triage new GitHub issues, hand severe ones to a reviewer agent,
-                notify #oncall."</span
-              >
-            </div>
-            <svg class="meta__arrow" viewBox="0 0 48 24" aria-hidden="true">
-              <path
-                d="M4 12 H36 M30 6 L40 12 L30 18"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="1.6"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-            <div class="meta__node meta__node--core">
-              <span class="meta__node-tag">02</span>
-              <span class="meta__node-title">Propose</span>
-              <span class="meta__node-sub"
-                >Two agents + peer wiring + webhook source + Slack channel — diff
-                shown, no secrets written.</span
-              >
-            </div>
-            <svg class="meta__arrow" viewBox="0 0 48 24" aria-hidden="true">
-              <path
-                d="M4 12 H36 M30 6 L40 12 L30 18"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="1.6"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-            <div class="meta__node meta__node--agent">
-              <span class="meta__node-tag">03</span>
-              <span class="meta__node-title">Apply &amp; deploy</span>
-              <span class="meta__node-sub"
-                ><code>/yes</code> → files written ·
-                <code>declaragent fleet run</code> → online.</span
-              >
-            </div>
-          </div>
-          <p class="meta__foot">
-            <span class="receipt">
-              <span class="receipt__ok">✓</span>
-              <code>14 builder tools · fleet-e2e test · git-rollback</code>
-            </span>
-            Not a wizard. Not a template gallery. A conversation with an agent
-            that understands the runtime it's authoring for — because it runs
-            on the same core.
-          </p>
-          <div class="hero__actions meta__cta">
-            <a
-              class="btn btn--accent"
-              href="https://docs.declaragent.dev/quickstart/conversational-tour"
-              target="_blank"
-              rel="noopener"
-              data-track="build:tour"
-            >
-              Take the 15-minute tour →
-            </a>
-            <a
-              class="btn btn--ghost"
-              href="https://docs.declaragent.dev/reference/builder"
-              target="_blank"
-              rel="noopener"
-              data-track="build:ref"
-            >
-              Builder reference
-            </a>
-          </div>
-        </div>
-      </section>
-
-      <!-- ───── HONEST STATUS ─────
-           The brand-defining section. Every competitor hides their 🟡.
-           We published ours — then shipped them. As of 0.7.1
-           (2026-04-23), the 12-item enterprise plan closed; all five
-           pillars flip to ✓ on both columns. Remaining caveat: Pillar
-           3 enterprise badge awaits first green `weekly-soak.yml` run
-           — the code + nightly CI ship today, the 7-consecutive-
-           greens soak proof is the last receipt. -->
-      <section class="ent" aria-labelledby="principles-title" id="honest-status">
-        <header class="ent__header">
-          <p class="eyebrow">Honest status · receipts-first</p>
-          <h2 id="principles-title">
-            Five pillars.
-            <span class="status-pair">
-              <span class="status status--ok">✓ single-machine</span>
-              <span class="status status--ok">✓ enterprise · v0.7.1</span>
-            </span>
-          </h2>
-          <p class="lede lede--muted">
-            Single-machine production shipped in 0.6.0. Multi-host RPC,
-            OIDC/OAuth2, a managed control plane, SIEM export, GitOps
-            <code>fleet render</code>, per-tool rate limits, MCP
-            auto-recovery and typed capability schemas shipped in 0.7.1.
-            Every ✓ below links to the PR that shipped it. The only open
-            receipt: the weekly cross-host soak proof for Pillar 3.
-          </p>
+      <!-- ───── HOW IT WORKS ───── -->
+      <section class="how" id="how" aria-labelledby="how-title">
+        <header class="sec__head">
+          <p class="sec__label">// the declarative loop</p>
+          <h2 id="how-title">Describe what you need. Review the plan. <span class="muted-strong">git commit.</span></h2>
         </header>
-        <div class="ent__grid">
-          <article class="ent-card pillar">
-            <header class="pillar__head">
-              <span class="pillar__num">01</span>
-              <h3>Define agents</h3>
-            </header>
-            <p>
-              <code>agent.yaml</code> identity + Markdown skills + tool
-              allowlists + inbound/outbound channels + typed peers.
-              v1.1 Agent Graph typed capabilities shipped in 0.7.1 (PR #23).
-            </p>
-            <footer class="pillar__foot">
-              <span class="status status--ok">✓ single-machine</span>
-              <span class="status status--ok">✓ enterprise · typed · v0.7.1</span>
-              <a
-                class="receipt-link"
-                href="https://docs.declaragent.dev/reference/agent-yaml"
-                target="_blank"
-                rel="noopener"
-                data-track="honest:p1"
-                >agent.yaml reference →</a
-              >
-            </footer>
-          </article>
-          <article class="ent-card pillar">
-            <header class="pillar__head">
-              <span class="pillar__num">02</span>
-              <h3>Deploy + monitor</h3>
-            </header>
-            <p>
-              <code>up / ps / logs / down</code>, Prometheus, OTel, circuit
-              breakers, canary deploys. Managed control plane aggregator,
-              GitOps <code>fleet render</code>, SIEM audit export — all
-              shipped in 0.7.1.
-            </p>
-            <footer class="pillar__foot">
-              <span class="status status--ok">✓ single-machine</span>
-              <span class="status status--ok">✓ enterprise · v0.7.1</span>
-              <a
-                class="receipt-link"
-                href="https://docs.declaragent.dev/reference/fleet"
-                target="_blank"
-                rel="noopener"
-                data-track="honest:p2"
-                >fleet reference →</a
-              >
-            </footer>
-          </article>
-          <article class="ent-card pillar">
-            <header class="pillar__head">
-              <span class="pillar__num">03</span>
-              <h3>Independent agents + delegation</h3>
-            </header>
-            <p>
-              Memory + Kafka + NATS RPC transports, pending-registry correlation,
-              version-skew detection, OIDC/OAuth2 on envelopes, fleet-e2e tests,
-              nightly CI on Redpanda.
-            </p>
-            <footer class="pillar__foot">
-              <span class="status status--ok">✓ single-machine</span>
-              <span class="status status--wip">◐ enterprise · soak proof pending</span>
-              <a
-                class="receipt-link"
-                href="https://docs.declaragent.dev/reference/rpc"
-                target="_blank"
-                rel="noopener"
-                data-track="honest:p3"
-                >rpc reference →</a
-              >
-            </footer>
-          </article>
-          <article class="ent-card pillar">
-            <header class="pillar__head">
-              <span class="pillar__num">04</span>
-              <h3>Tools + MCP</h3>
-            </header>
-            <p>
-              8 built-ins (Read, Write, Edit, Bash, Glob, Grep, Agent,
-              SendMessage) + MCP stdio/HTTP/SSE/streamable-HTTP + OAuth 2.1
-              PKCE + per-tool rate limits + auto-recovery for crashed MCP
-              servers (0.7.1).
-            </p>
-            <footer class="pillar__foot">
-              <span class="status status--ok">✓ single-machine</span>
-              <span class="status status--ok">✓ enterprise · v0.7.1</span>
-              <a
-                class="receipt-link"
-                href="https://docs.declaragent.dev/reference/extensions"
-                target="_blank"
-                rel="noopener"
-                data-track="honest:p4"
-                >extensions ref →</a
-              >
-            </footer>
-          </article>
-          <article class="ent-card pillar">
-            <header class="pillar__head">
-              <span class="pillar__num">05</span>
-              <h3>Conversational builder</h3>
-            </header>
-            <p>
-              14 builder tools, plan-confirm-execute, git-backed rollback,
-              scope + secret guards, fleet-e2e test, recorded-conversation
-              regression suite (0.7.1).
-            </p>
-            <footer class="pillar__foot">
-              <span class="status status--ok">✓ single-machine</span>
-              <span class="status status--ok">✓ enterprise · regression tests · v0.7.1</span>
-              <a
-                class="receipt-link"
-                href="https://docs.declaragent.dev/reference/builder"
-                target="_blank"
-                rel="noopener"
-                data-track="honest:p5"
-                >builder reference →</a
-              >
-            </footer>
-          </article>
-          <article class="ent-card pillar pillar--honesty">
-            <header class="pillar__head">
-              <span class="pillar__num">∎</span>
-              <h3>The honesty clause</h3>
-            </header>
-            <p>
-              Every ✓ has a test. Every ◐ names the gap. Each item on
-              the next rail links to the PR that shipped it — the
-              evidence is public, versioned, and reviewable.
-            </p>
-            <footer class="pillar__foot">
-              <a
-                class="btn btn--ghost btn--compact"
-                href="https://github.com/declaragent/declaragent/releases"
-                target="_blank"
-                rel="noopener"
-                data-track="honest:releases"
-                >See all releases →</a
-              >
-            </footer>
-          </article>
+        <ol class="loop">
+          <li class="loop__step">
+            <span class="loop__n">01</span>
+            <h3>Describe</h3>
+            <p>Talk to the builder in plain language, or hand-write the YAML. It scaffolds skills, sources, channels, MCP servers and peers.</p>
+            <pre class="loop__code"><code><span class="c-dim">$</span> declaragent build
+<span class="c-dim">›</span> a Slack bot that triages
+  GitHub issues every morning…</code></pre>
+          </li>
+          <li class="loop__step">
+            <span class="loop__n">02</span>
+            <h3>Review the plan</h3>
+            <p>Every change is a reviewable diff against your repo before anything runs. No magic, no hidden state — what you read is what deploys.</p>
+            <pre class="loop__code"><code><span class="c-ok">+ agents/triager/agent.yaml</span>
+<span class="c-ok">+ agents/triager/skills/triage.md</span>
+<span class="c-dim">  fleet.yaml (+1 agent)</span></code></pre>
+          </li>
+          <li class="loop__step">
+            <span class="loop__n">03</span>
+            <h3>Apply &amp; operate</h3>
+            <p>One CLI for the whole lifecycle — bring it up, watch it, ship it. Prometheus, OTel, audit and circuit breakers are on by default.</p>
+            <pre class="loop__code"><code><span class="c-dim">$</span> declaragent up -d
+<span class="c-dim">$</span> declaragent logs -f
+<span class="c-dim">$</span> declaragent deploy gcp-cloud-run</code></pre>
+          </li>
+        </ol>
+        <div class="lifecycle">
+          <span class="lifecycle__label">one binary, every step</span>
+          <span class="lifecycle__chain">
+            <code>init</code><span>→</span><code>auth</code><span>→</span><code>up</code><span>→</span><code>ps / logs</code><span>→</span><code>events / audit</code><span>→</span><code>fleet</code><span>→</span><code>deploy</code>
+          </span>
         </div>
-
-        <!-- "Just shipped" rail — the receipts-first brand signature
-             inverted. These items were openly listed as 🟡 gaps on this
-             page until 2026-04-23 when cli@0.7.1 closed the 12-item
-             enterprise plan. We're leaving the shape of the rail in
-             place so anyone comparing Wayback snapshots sees us walk
-             the talk: named the gaps, shipped the fixes, linked the PRs. -->
-        <aside class="shipped" aria-label="Just shipped — enterprise plan">
-          <p class="shipped__eyebrow">Just shipped in v0.7.1 — 12 / 12 enterprise items ✓</p>
-          <ul class="shipped__list" role="list">
-            <li class="shipped__item">
-              <span class="shipped__mark">✓</span>
-              <span class="shipped__title">Kafka soak — cross-host <code>fleet run</code> + 24h drift alarm</span>
-              <span class="shipped__gap">literal Kafka soak subprocess + nightly CI</span>
-              <a
-                class="shipped__pr"
-                href="https://github.com/declaragent/declaragent/pull/10"
-                target="_blank"
-                rel="noopener"
-                data-track="shipped:p1"
-                >#10</a
-              >
-            </li>
-            <li class="shipped__item">
-              <span class="shipped__mark">✓</span>
-              <span class="shipped__title">NATS RPC transport factory</span>
-              <span class="shipped__gap">per-topic queue groups · round-trip tested</span>
-              <a
-                class="shipped__pr"
-                href="https://github.com/declaragent/declaragent/pull/13"
-                target="_blank"
-                rel="noopener"
-                data-track="shipped:p2"
-                >#13</a
-              >
-            </li>
-            <li class="shipped__item">
-              <span class="shipped__mark">✓</span>
-              <span class="shipped__title">Dispatch-DLQ active requeue</span>
-              <span class="shipped__gap">via <code>up</code> control socket</span>
-              <a
-                class="shipped__pr"
-                href="https://github.com/declaragent/declaragent/pull/14"
-                target="_blank"
-                rel="noopener"
-                data-track="shipped:p3"
-                >#14</a
-              >
-            </li>
-            <li class="shipped__item">
-              <span class="shipped__mark">✓</span>
-              <span class="shipped__title">OIDC / OAuth2 on RPC envelopes</span>
-              <span class="shipped__gap"><code>AuthVerifyRegistry</code> + <code>RPC_ERROR_CODES.AUTH_REJECTED</code></span>
-              <a
-                class="shipped__pr"
-                href="https://github.com/declaragent/declaragent/pull/17"
-                target="_blank"
-                rel="noopener"
-                data-track="shipped:p4"
-                >#17</a
-              >
-            </li>
-            <li class="shipped__item">
-              <span class="shipped__mark">✓</span>
-              <span class="shipped__title">Managed control plane — aggregator over N <code>up</code></span>
-              <span class="shipped__gap">Slice 1 full + Slice 2 auth middleware</span>
-              <a
-                class="shipped__pr"
-                href="https://github.com/declaragent/declaragent/pull/27"
-                target="_blank"
-                rel="noopener"
-                data-track="shipped:p5"
-                >#12 · #15 · #19 · #27</a
-              >
-            </li>
-            <li class="shipped__item">
-              <span class="shipped__mark">✓</span>
-              <span class="shipped__title">Control socket on <code>up</code> daemon</span>
-              <span class="shipped__gap"><code>status</code> + <code>dlq.requeue</code> ops</span>
-              <a
-                class="shipped__pr"
-                href="https://github.com/declaragent/declaragent/pull/11"
-                target="_blank"
-                rel="noopener"
-                data-track="shipped:p6"
-                >#11</a
-              >
-            </li>
-            <li class="shipped__item">
-              <span class="shipped__mark">✓</span>
-              <span class="shipped__title">Per-tool rate limit</span>
-              <span class="shipped__gap">token bucket + comparator/burst defaults</span>
-              <a
-                class="shipped__pr"
-                href="https://github.com/declaragent/declaragent/pull/18"
-                target="_blank"
-                rel="noopener"
-                data-track="shipped:p7"
-                >#18</a
-              >
-            </li>
-            <li class="shipped__item">
-              <span class="shipped__mark">✓</span>
-              <span class="shipped__title">Auto-recovery for crashed MCP servers</span>
-              <span class="shipped__gap">supervised recipe + <code>circuit-open</code> counter</span>
-              <a
-                class="shipped__pr"
-                href="https://github.com/declaragent/declaragent/pull/21"
-                target="_blank"
-                rel="noopener"
-                data-track="shipped:p8"
-                >#21</a
-              >
-            </li>
-            <li class="shipped__item">
-              <span class="shipped__mark">✓</span>
-              <span class="shipped__title">GitOps <code>fleet render</code> — k8s manifests + Helm</span>
-              <span class="shipped__gap">with <code>--no-servicemonitor</code> escape</span>
-              <a
-                class="shipped__pr"
-                href="https://github.com/declaragent/declaragent/pull/20"
-                target="_blank"
-                rel="noopener"
-                data-track="shipped:p9"
-                >#20</a
-              >
-            </li>
-            <li class="shipped__item">
-              <span class="shipped__mark">✓</span>
-              <span class="shipped__title">SIEM audit export — Splunk / Elastic / Datadog</span>
-              <span class="shipped__gap">cursor held across restarts</span>
-              <a
-                class="shipped__pr"
-                href="https://github.com/declaragent/declaragent/pull/22"
-                target="_blank"
-                rel="noopener"
-                data-track="shipped:p10"
-                >#22</a
-              >
-            </li>
-            <li class="shipped__item">
-              <span class="shipped__mark">✓</span>
-              <span class="shipped__title">v1.1 Agent Graph — typed capabilities</span>
-              <span class="shipped__gap">draft-07 validator + deterministic codegen</span>
-              <a
-                class="shipped__pr"
-                href="https://github.com/declaragent/declaragent/pull/23"
-                target="_blank"
-                rel="noopener"
-                data-track="shipped:p11"
-                >#23</a
-              >
-            </li>
-            <li class="shipped__item">
-              <span class="shipped__mark">✓</span>
-              <span class="shipped__title">Recorded-conversation builder regression tests</span>
-              <span class="shipped__gap">5 canonical fixtures + replay harness + PR-template gate</span>
-              <a
-                class="shipped__pr"
-                href="https://github.com/declaragent/declaragent/pull/24"
-                target="_blank"
-                rel="noopener"
-                data-track="shipped:p12"
-                >#24</a
-              >
-            </li>
-          </ul>
-          <p class="shipped__foot">
-            One receipt still in flight: the weekly cross-host soak
-            proof for Pillar 3. Running evidence lives in the
-            <a
-              href="https://github.com/declaragent/declaragent/blob/main/packages/cli/CHANGELOG.md"
-              target="_blank"
-              rel="noopener"
-              data-track="shipped:changelog"
-              >public changelog ↗</a
-            >.
-          </p>
-        </aside>
       </section>
 
-      <!-- ───── CAPABILITIES ───── -->
-      <section class="caps" aria-labelledby="caps-title" id="capabilities">
-        <header class="caps__header">
-          <p class="eyebrow">Capabilities · declarative</p>
-          <h2 id="caps-title">What you can add to an agent.</h2>
-          <p class="lede lede--muted">
-            Every block below is declarative in <code>agent.yaml</code> and
-            installable through the CLI. No hidden console, no vendor dashboard,
-            no "contact sales."
-          </p>
+      <!-- ───── CAPABILITIES (deduplicated, grouped) ───── -->
+      <section class="caps" id="capabilities" aria-labelledby="caps-title">
+        <header class="sec__head">
+          <p class="sec__label">// what's in the box</p>
+          <h2 id="caps-title">Everything an agent needs — declared, not wired by hand.</h2>
+          <p class="sec__sub">Four groups, no duplication. Each capability ships in <code>@declaragent/cli@0.7.6</code> and is graded in the status ledger below.</p>
         </header>
-
         <div class="caps__grid">
           <article class="cap">
-            <div class="cap__head">
-              <span class="cap__tag">tools</span>
-              <h3>Built-in tools</h3>
-            </div>
-            <p>
-              Read, Write, Edit, Bash, Glob, Grep, Agent, SendMessage. File-system
-              grounded. MCP server tools load on top.
-            </p>
-            <pre class="cap__code"><code>tools:
-  defaults: [Read, Glob, Grep, Bash]</code></pre>
-            <a
-              class="cap__link"
-              href="https://docs.declaragent.dev/reference/agent-yaml"
-              target="_blank"
-              rel="noopener"
-              >Tools reference →</a
-            >
-          </article>
-
-          <article class="cap">
-            <div class="cap__head">
-              <span class="cap__tag">skills</span>
-              <h3>Markdown skills</h3>
-            </div>
-            <p>
-              Prompts + input schema in one Markdown file with frontmatter.
-              <code>{{var}}</code> interpolation. Tiered discovery (user /
-              project / plugin).
-            </p>
-            <pre class="cap__code"><code>skills:
-  - skills/review-pr.md</code></pre>
-            <a
-              class="cap__link"
-              href="https://docs.declaragent.dev/reference/agent-yaml"
-              target="_blank"
-              rel="noopener"
-              >Skills reference →</a
-            >
-          </article>
-
-          <article class="cap">
-            <div class="cap__head">
-              <span class="cap__tag">plugins</span>
-              <h3>npm plugins</h3>
-            </div>
-            <p>
-              Bundle skills, tools, channels, sources. Consent-gated permission
-              grants on install. Versioned via changesets.
-            </p>
-            <pre class="cap__code"><code>$ declaragent plugin install \
-    @declaragent/plugin-github</code></pre>
-            <a
-              class="cap__link"
-              href="https://docs.declaragent.dev/reference/extensions"
-              target="_blank"
-              rel="noopener"
-              >Plugin system →</a
-            >
-          </article>
-
-          <article class="cap">
-            <div class="cap__head">
-              <span class="cap__tag">mcp</span>
-              <h3>MCP servers</h3>
-            </div>
-            <p>
-              First-class Model Context Protocol support — stdio + HTTP. Tools,
-              resources, prompts. One-command registration.
-            </p>
-            <pre class="cap__code"><code>$ declaragent mcp add postgres \
-    --command psql-mcp</code></pre>
-            <a
-              class="cap__link"
-              href="https://docs.declaragent.dev/reference/extensions"
-              target="_blank"
-              rel="noopener"
-              >MCP reference →</a
-            >
-          </article>
-
-          <article class="cap">
-            <div class="cap__head">
-              <span class="cap__tag">sources</span>
-              <h3>Event sources</h3>
-            </div>
-            <p>
-              Cron, webhook, file-watch, Kafka
-              <span class="status-inline status-inline--ok">✓</span>, NATS · SQS
-              · AMQP · MQTT
-              <span class="status-inline status-inline--wip">◐</span>. DLQ +
-              replay + idempotency + rate limiting — declaratively.
-            </p>
-            <pre class="cap__code"><code>$ declaragent source add webhook \
-    gh-events --config-file ./hook.yaml</code></pre>
-            <a
-              class="cap__link"
-              href="https://docs.declaragent.dev/reference/extensions"
-              target="_blank"
-              rel="noopener"
-              >Source adapters →</a
-            >
-          </article>
-
-          <article class="cap">
-            <div class="cap__head">
-              <span class="cap__tag">channels</span>
-              <h3>Chat channels</h3>
-            </div>
-            <p>
-              Slack, Telegram, Discord, WhatsApp. Outbound rate limits, send
-              idempotency, per-user session context, BlockKit / Markdown
-              rendering.
-            </p>
-            <pre class="cap__code"><code>channels:
-  - id: slack-prod
-    type: slack</code></pre>
-            <a
-              class="cap__link"
-              href="https://docs.declaragent.dev/reference/extensions"
-              target="_blank"
-              rel="noopener"
-              >Channel registry →</a
-            >
-          </article>
-
-          <article class="cap">
-            <div class="cap__head">
-              <span class="cap__tag">tenancy</span>
-              <h3>Multi-tenant isolation</h3>
-            </div>
-            <p>
-              One daemon, many tenants. Per-tenant quotas, extension scopes,
-              residency tags, tenant-stamped buses.
-            </p>
-            <pre class="cap__code"><code>$ declaragent tenants show acme-prod
-$ declaragent tenants diff</code></pre>
-            <a
-              class="cap__link"
-              href="https://docs.declaragent.dev/cookbook/two-tenants-one-daemon"
-              target="_blank"
-              rel="noopener"
-              >Multi-tenant guide →</a
-            >
-          </article>
-
-          <article class="cap">
-            <div class="cap__head">
-              <span class="cap__tag">secrets</span>
-              <h3>Secrets rotation</h3>
-            </div>
-            <p>
-              Vault, AWS Secrets Manager, GCP Secret Manager, K8s, env. TTL
-              cache, audit on every resolve, rotation monitor.
-            </p>
-            <pre class="cap__code"><code>$ declaragent secrets rotate \
-    vault:kv/acme/gh-token</code></pre>
-            <a
-              class="cap__link"
-              href="https://docs.declaragent.dev/cookbook/rotate-vault-secret"
-              target="_blank"
-              rel="noopener"
-              >Secrets reference →</a
-            >
-          </article>
-
-          <article class="cap">
-            <div class="cap__head">
-              <span class="cap__tag">audit</span>
-              <h3>Hash-chained audit</h3>
-            </div>
-            <p>
-              Every tool call, channel send, tenant boundary, secret access.
-              SHA-256 chain verify. GDPR erase by user or correlationId.
-            </p>
-            <pre class="cap__code"><code>$ declaragent audit verify
-$ declaragent audit erase --user U123</code></pre>
-            <a
-              class="cap__link"
-              href="https://docs.declaragent.dev/reference/agent-yaml"
-              target="_blank"
-              rel="noopener"
-              >Audit format →</a
-            >
-          </article>
-
-          <article class="cap">
-            <div class="cap__head">
-              <span class="cap__tag">permissions</span>
-              <h3>Permission gate</h3>
-            </div>
-            <p>
-              Four modes: default (prompt per call), plan (dry-run), bypass
-              (trusted), auto (auto-approve allow-list). Sandboxing on file +
-              shell.
-            </p>
-            <pre class="cap__code"><code>$ declaragent --mode plan
-$ declaragent --mode auto</code></pre>
-            <a
-              class="cap__link"
-              href="https://docs.declaragent.dev/reference/agent-yaml"
-              target="_blank"
-              rel="noopener"
-              >Permission modes →</a
-            >
-          </article>
-
-          <article class="cap">
-            <div class="cap__head">
-              <span class="cap__tag">observability</span>
-              <h3>Metrics + traces</h3>
-            </div>
-            <p>
-              Prometheus exporter with per-tenant labels. OpenTelemetry spans
-              for every turn + tool call. Structured logs with correlationId
-              threading.
-            </p>
-            <pre class="cap__code"><code>observability:
-  prometheus: { port: 9464 }
-  otel: { endpoint: $OTEL_URL }</code></pre>
-            <a
-              class="cap__link"
-              href="https://docs.declaragent.dev/cookbook/grafana-tracing"
-              target="_blank"
-              rel="noopener"
-              >Grafana setup →</a
-            >
-          </article>
-
-          <article class="cap">
-            <div class="cap__head">
-              <span class="cap__tag">fleets</span>
-              <h3>Multi-agent fleets</h3>
-            </div>
-            <p>
-              One <code>fleet.yaml</code> declares N agents + shared peer table.
-              Inter-agent RPC, rolling / all-or-nothing deploy, version-skew
-              detection.
-            </p>
-            <pre class="cap__code"><code>$ declaragent fleet new acme-fleet
-$ declaragent fleet run</code></pre>
-            <a
-              class="cap__link"
-              href="https://docs.declaragent.dev/reference/fleet"
-              target="_blank"
-              rel="noopener"
-              >Fleet reference →</a
-            >
-          </article>
-        </div>
-      </section>
-
-      <!-- ───── LIFECYCLE ───── -->
-      <section class="lifecycle" aria-labelledby="lifecycle-title">
-        <header class="lifecycle__header">
-          <p class="eyebrow">Lifecycle · one binary</p>
-          <h2 id="lifecycle-title">One CLI. Every step of the agent lifecycle.</h2>
-          <p class="lede lede--muted">
-            No separate tools for init vs. deploy vs. ops. The same binary you
-            install on your laptop runs in CI and talks to the daemon in
-            production. <code>declaragent</code> is the long form;
-            <code>d9t</code> is the short.
-          </p>
-        </header>
-
-        <div class="lifecycle__grid">
-          <div class="stage">
-            <div class="stage__num">01</div>
-            <h3>Build</h3>
-            <pre class="stage__code"><code>declaragent init --fleet acme
-cd acme
-
-DECLARAGENT_BUILDER=on declaragent
-&gt; build a fleet that triages GH
-&gt;   issues and hands severe ones
-&gt;   to a reviewer agent
-/yes</code></pre>
-            <p>Scaffold a fleet, then converse to shape it. Templates still work.</p>
-          </div>
-
-          <div class="stage">
-            <div class="stage__num">02</div>
-            <h3>Configure</h3>
-            <pre class="stage__code"><code>declaragent plugin install \
-  @declaragent/plugin-github
-
-declaragent source add webhook \
-  gh-events --config-file ./hook.yaml
-
-declaragent mcp add postgres \
-  --command psql-mcp</code></pre>
-            <p>Add plugins, event sources, MCP servers, channels. Consent-gated.</p>
-          </div>
-
-          <div class="stage">
-            <div class="stage__num">03</div>
-            <h3>Operate</h3>
-            <pre class="stage__code"><code>declaragent daemon
-declaragent events list --last 20
-declaragent dlq redrive \
-  --source webhook:gh-events &lt;id&gt;
-declaragent audit verify
-declaragent tenants show acme-prod</code></pre>
-            <p>Run locally or as a daemon. Observe, replay, audit, debug.</p>
-          </div>
-
-          <div class="stage">
-            <div class="stage__num">04</div>
-            <h3>Deploy</h3>
-            <pre class="stage__code"><code>declaragent deploy gcp-cloud-run \
-  --project acme --region us-central1
-
-declaragent fleet deploy \
-  --target cloud-run
-declaragent fleet deploy --rollback</code></pre>
-            <p>Single agent or whole fleet. Rolling, health-gated, rollback-ready.</p>
-          </div>
-        </div>
-      </section>
-
-      <!-- ───── META — declaragent is an agent ───── -->
-      <section class="meta" aria-labelledby="meta-title">
-        <div class="meta__inner">
-          <p class="eyebrow">Built with itself</p>
-          <h2 id="meta-title"><code>declaragent</code> is an agent.</h2>
-          <p class="lede lede--muted">
-            Launch the REPL, you're talking to an agent built on
-            <code>@declaragent/core</code> — the same runtime, same tools, same
-            audit chain, same permission gate you'd use to build your own. One
-            core, many agents. No second implementation, no "CLI-only" features
-            locked out of your production path.
-          </p>
-          <div class="meta__flow" aria-label="One core, three agents">
-            <div class="meta__node meta__node--core">
-              <span class="meta__node-tag">core</span>
-              <span class="meta__node-title">@declaragent/core</span>
-              <span class="meta__node-sub"
-                >engine · tools · audit · permissions</span
-              >
-            </div>
-            <svg class="meta__arrow" viewBox="0 0 48 24" aria-hidden="true">
-              <path
-                d="M4 12 H36 M30 6 L40 12 L30 18"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="1.6"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-            <div class="meta__node meta__node--agent">
-              <span class="meta__node-tag">agent #1</span>
-              <span class="meta__node-title">declaragent REPL</span>
-              <span class="meta__node-sub"
-                >the CLI you install — itself an agent</span
-              >
-            </div>
-            <svg class="meta__arrow" viewBox="0 0 48 24" aria-hidden="true">
-              <path
-                d="M4 12 H36 M30 6 L40 12 L30 18"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="1.6"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
-            <div class="meta__node meta__node--agent">
-              <span class="meta__node-tag">agent #2…N</span>
-              <span class="meta__node-title">your agent.yaml</span>
-              <span class="meta__node-sub"
-                >every agent you declare + ship</span
-              >
-            </div>
-          </div>
-          <p class="meta__foot">
-            Same <code>Tool</code> contract. Same permission gate. Same audit
-            sink. If your agent can do it, so can the CLI. If the CLI does it,
-            your agent can inherit it.
-          </p>
-        </div>
-      </section>
-
-      <!-- ───── ENTERPRISE PRIMITIVES ───── -->
-      <section class="ent" aria-labelledby="ent-title">
-        <header class="ent__header">
-          <p class="eyebrow">Enterprise primitives · built-in</p>
-          <h2 id="ent-title">
-            Built for the ops team, not just the prompt engineer.
-          </h2>
-        </header>
-        <div class="ent__grid">
-          <article class="ent-card">
-            <h3>Audit &amp; compliance</h3>
-            <p>
-              Every tool call, channel send, tenant boundary, and secret resolve
-              is recorded to a SHA-256 hash chain. <code>audit verify</code>
-              detects tampering; <code>audit erase --user</code> tombstones in a
-              GDPR-clean pass.
-            </p>
-          </article>
-          <article class="ent-card">
-            <h3>Multi-tenant isolation</h3>
-            <p>
-              One <code>tenants.yaml</code> declares quotas, residency,
-              extension allow/deny, and per-tenant secret scopes. The event bus
-              is tenant-stamped; cross-tenant writes fail closed with a typed
-              error.
-            </p>
-          </article>
-          <article class="ent-card">
-            <h3>Secrets rotation</h3>
-            <p>
-              Native providers for Vault, AWS Secrets Manager, GCP Secret
-              Manager, K8s, and env. TTL cache + rotation monitor. Every resolve
-              writes a <code>secret_access</code> audit record.
-            </p>
-          </article>
-          <article class="ent-card">
-            <h3>Permission gate</h3>
-            <p>
-              Four runtime modes — default (prompt per call), plan, bypass, auto
-              (allow-list). File-system sandboxing, per-tool allow/deny globs,
-              escalation on denial.
-            </p>
-          </article>
-          <article class="ent-card">
-            <h3>Observability</h3>
-            <p>
-              Prometheus exporter with <code>tenant_id</code> constLabels baked
-              in. OpenTelemetry spans thread through every turn, tool call, and
-              RPC hop. Structured logs keyed on <code>correlationId</code>.
-            </p>
-          </article>
-          <article class="ent-card">
-            <h3>Deploy automation</h3>
-            <p>
-              Cloud Run deploy templates generated from <code>agent.yaml</code>.
-              Fleet deploys support rolling / all-or-nothing / per-agent with
-              health-gated rollback. Every deploy records a version; one flag
-              reverts.
-            </p>
-          </article>
-        </div>
-      </section>
-
-      <!-- ───── VALIDATOR ─────
-           Interactive moment. Kept because it's the single most memorable
-           thing on the page — the product literally runs in your browser. -->
-      <section class="validator" aria-labelledby="validator-title">
-        <header class="validator__header">
-          <p class="eyebrow">Interactive · no install</p>
-          <h2 id="validator-title">
-            Paste a <code>fleet.yaml</code>. Run the production validator
-            <span class="accent">in your browser.</span>
-          </h2>
-          <p class="lede lede--muted">
-            Same validation logic that ships in <code>@declaragent/cli</code>,
-            ported verbatim. Dangle a peer, duplicate a capability, reference a
-            missing deploy target — findings appear inline, offline, no
-            network hop.
-          </p>
-        </header>
-
-        <div class="validator__grid">
-          <div class="editor" data-role="editor">
-            <div class="editor__tab">fleet.yaml</div>
-            <textarea
-              id="yaml-input"
-              spellcheck="false"
-              autocomplete="off"
-              autocorrect="off"
-              autocapitalize="off"
-              aria-label="fleet.yaml source"
-            ></textarea>
-          </div>
-
-          <div class="findings" id="findings" aria-live="polite">
-            <div class="findings__header">
-              <span class="findings__title">Findings</span>
-              <button
-                class="btn btn--accent btn--compact"
-                id="validate-btn"
-                type="button"
-                data-track="validator:run"
-              >
-                Validate
-              </button>
-            </div>
-            <ul class="findings__list" id="findings-list">
-              <li class="findings__placeholder">Click Validate to run.</li>
+            <h3><span class="cap__i">⌥</span> Define</h3>
+            <ul>
+              <li><b>agent.yaml</b> — identity, model, temperature, deploy</li>
+              <li><b>Markdown skills</b> — routed by event &amp; intent</li>
+              <li><b>npm plugins</b> — drop-in capability packages</li>
+              <li><b>MCP servers</b> — stdio / HTTP / SSE / OAuth PKCE</li>
+              <li><b>8 built-in tools</b> — read, write, bash, grep…</li>
             </ul>
+          </article>
+          <article class="cap">
+            <h3><span class="cap__i">⇄</span> Connect</h3>
+            <ul>
+              <li><b>Event sources</b> — webhook, cron, file-watch</li>
+              <li><b>Brokers</b> — Kafka, NATS, JetStream, SQS, AMQP, MQTT</li>
+              <li><b>Chat channels</b> — Slack, Telegram, Discord, WhatsApp</li>
+              <li><b>Agent-to-agent RPC</b> — independent agents, optional delegation</li>
+            </ul>
+          </article>
+          <article class="cap">
+            <h3><span class="cap__i">◎</span> Run &amp; observe</h3>
+            <ul>
+              <li><b>Prometheus</b> <code>/metrics</code> on by default</li>
+              <li><b>OpenTelemetry</b> traces per turn</li>
+              <li><b>Circuit breakers</b> + per-tool &amp; provider rate limits</li>
+              <li><b>Dispatch DLQ</b> — list, requeue, drop</li>
+            </ul>
+          </article>
+          <article class="cap">
+            <h3><span class="cap__i">⛨</span> Govern</h3>
+            <ul>
+              <li><b>Hash-chained audit</b> — tamper-evident, GDPR-erase-safe</li>
+              <li><b>Multi-tenant isolation</b> + per-tenant quotas</li>
+              <li><b>Secrets</b> — Vault, AWS SM, GCP SM resolvers</li>
+              <li><b>Permission gate</b> — every tool call, every turn</li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <!-- ───── HONEST STATUS LEDGER (the centerpiece) ───── -->
+      <section class="status" id="status" aria-labelledby="status-title">
+        <header class="sec__head sec__head--center">
+          <p class="sec__label">// receipts, not promises</p>
+          <h2 id="status-title">The honest status ledger</h2>
+          <p class="sec__sub">
+            Five pillars, graded twice: where it runs on one machine, and where it stands for
+            multi-host enterprise scale. <b class="legend"><span class="dot dot--ok"></span>✓ shipped</b>
+            <b class="legend"><span class="dot dot--warn"></span>◐ partial</b>
+            <b class="legend"><span class="dot dot--dim"></span>○ tracked</b>
+          </p>
+        </header>
+
+        <div class="ledger" role="table" aria-label="Capability status by pillar">
+          <div class="ledger__row ledger__row--head" role="row">
+            <span role="columnheader">Pillar</span>
+            <span role="columnheader" class="ledger__grade-h">single-machine</span>
+            <span role="columnheader" class="ledger__grade-h">enterprise</span>
+          </div>
+
+          <div class="ledger__row" role="row">
+            <span class="ledger__pillar"><b>Define agents</b><i>capabilities, skills, channels, peers</i></span>
+            <span class="grade grade--ok" role="cell">✓ shipped</span>
+            <span class="grade grade--warn" role="cell">◐ SSO-bridged channel perms in progress</span>
+          </div>
+          <div class="ledger__row" role="row">
+            <span class="ledger__pillar"><b>Deploy + monitor fleet</b><i>up/down/ps/logs · Prometheus · OTel</i></span>
+            <span class="grade grade--ok" role="cell">✓ shipped</span>
+            <span class="grade grade--warn" role="cell">◐ cross-host fan-out live · traffic-split canary tracked</span>
+          </div>
+          <div class="ledger__row" role="row">
+            <span class="ledger__pillar"><b>Independent agents</b><i>memory · Kafka/NATS/SQS/AMQP/MQTT RPC</i></span>
+            <span class="grade grade--ok" role="cell">✓ shipped</span>
+            <span class="grade grade--warn" role="cell">◐ 24h Kafka soak still accruing green runs</span>
+          </div>
+          <div class="ledger__row" role="row">
+            <span class="ledger__pillar"><b>Tools + MCP</b><i>8 built-ins · MCP · plugins · auto-recovery</i></span>
+            <span class="grade grade--ok" role="cell">✓ shipped</span>
+            <span class="grade grade--warn" role="cell">◐ approval workflows on the roadmap</span>
+          </div>
+          <div class="ledger__row" role="row">
+            <span class="ledger__pillar"><b>Conversational builder</b><i>chat → deployable fleet</i></span>
+            <span class="grade grade--ok" role="cell">✓ shipped</span>
+            <span class="grade grade--warn" role="cell">◐ fixture polish open, non-blocking</span>
+          </div>
+        </div>
+
+        <div class="honesty">
+          <p class="honesty__title"><span class="cap__i">§</span> The honesty clause</p>
+          <p>
+            Single-machine production is real and shipping on npm today. <b>Enterprise is ◐, on purpose:</b>
+            the primitives are built and tested, but they aren't yet soak-proven at scale, third-party
+            pen-tested, or running in anyone's production but the maintainer's. We grade against
+            <a href="https://github.com/declaragent/declaragent/blob/main/AGENTS.md" target="_blank" rel="noopener" data-track="status:agents">AGENTS.md</a> —
+            every ✓ links to a test or a <code>file:line</code>. When a soak run goes red, the grade is
+            supposed to move with it, not the marketing.
+          </p>
+        </div>
+      </section>
+
+      <!-- ───── IN-BROWSER VALIDATOR (functional, preserved) ───── -->
+      <section class="validator" id="validator" aria-labelledby="val-title">
+        <header class="sec__head">
+          <p class="sec__label">// try it — runs entirely in your browser</p>
+          <h2 id="val-title">Paste a <code>fleet.yaml</code>. Validate it here.</h2>
+          <p class="sec__sub">The same manifest checks the CLI runs, ported to the page. Nothing leaves your tab.</p>
+        </header>
+        <div class="validator__panes">
+          <div class="validator__editor">
+            <div class="validator__editor-bar"><span>fleet.yaml</span></div>
+            <textarea id="yaml-input" spellcheck="false" aria-label="fleet.yaml input"></textarea>
+          </div>
+          <div class="validator__out">
+            <div class="validator__out-bar">
+              <span>findings</span>
+              <button id="validate-btn" class="btn btn--accent" type="button" data-track="validator:run">Validate ▸</button>
+            </div>
+            <ul id="findings-list" class="findings" aria-live="polite"></ul>
           </div>
         </div>
       </section>
 
-      <!-- ───── FINAL STAR CTA ─────
-           The page's single most important conversion event. Dedicated
-           block, single action, no distractions. -->
-      <section class="star-cta" aria-labelledby="star-cta-title">
-        <div class="star-cta__inner">
-          <p class="eyebrow">If this saves you an afternoon</p>
-          <h2 id="star-cta-title">Star it on GitHub.</h2>
-          <p class="lede lede--muted">
-            One click. No account creation, no email capture, no newsletter
-            trap. Stars are the signal maintainers read first when prioritizing
-            the next week of work.
-          </p>
-          <div class="star-cta__actions">
-            <a
-              class="btn btn--accent btn--large"
-              href="https://github.com/declaragent/declaragent"
-              target="_blank"
-              rel="noopener"
-              data-track="cta:star"
-            >
-              <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true">
-                <path
-                  fill="currentColor"
-                  d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.72 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"
-                />
-              </svg>
-              Star on GitHub
-            </a>
-            <a
-              class="btn btn--ghost btn--large"
-              href="https://github.com/declaragent/declaragent/discussions"
-              target="_blank"
-              rel="noopener"
-              data-track="cta:discuss"
-            >
-              Join discussions
-            </a>
-          </div>
-          <p class="star-cta__foot">
-            Or watch the repo — release notes, RFCs, and the nightly soak
-            dashboard all land there first.
-          </p>
+      <!-- ───── CTA ───── -->
+      <section class="cta" aria-labelledby="cta-title">
+        <p class="sec__label">// $ npm i -g @declaragent/cli</p>
+        <h2 id="cta-title">Built primarily by an agent, for people who run agents.</h2>
+        <p class="cta__sub">
+          An unusually thoughtful declarative runtime with serious primitives — open source,
+          0.x, looking for its first production users. If that's you, we'd love to hear it.
+        </p>
+        <div class="cta__row">
+          <a class="btn btn--accent btn--lg" href="https://github.com/declaragent/declaragent" target="_blank" rel="noopener" data-track="cta:star">★ Star on GitHub</a>
+          <a class="btn btn--ghost btn--lg" href="https://docs.declaragent.dev/quickstart" target="_blank" rel="noopener" data-track="cta:quickstart">Read the quickstart</a>
+          <a class="btn btn--ghost btn--lg" href="https://www.npmjs.com/package/@declaragent/cli" target="_blank" rel="noopener" data-track="cta:npm">@declaragent/cli</a>
         </div>
       </section>
     </main>
 
+    <!-- ───── FOOTER ───── -->
     <footer class="site-footer">
-      <div class="site-footer__inner">
+      <div class="site-footer__top">
         <div class="site-footer__brand">
-          <span>declaragent</span>
-          <span class="site-footer__tagline"
-            >Production AI agents, declared in your repo.</span
-          >
+          <span class="brand__name">declaragent<span class="brand__alias">d9t</span></span>
+          <p>Declarative, git-versioned AI agents. An agent that helps you build and run fleets of agents.</p>
+          <p class="site-footer__ai">Built primarily by Claude under one human reviewer. <a href="https://github.com/declaragent/declaragent/blob/main/GOVERNANCE.md" target="_blank" rel="noopener" data-track="footer:governance">How &amp; why →</a></p>
         </div>
-        <div class="site-footer__links">
-          <a
-            href="https://github.com/declaragent/declaragent"
-            target="_blank"
-            rel="noopener"
-            data-track="footer:github"
-            >GitHub</a
-          >
-          <a
-            href="https://www.npmjs.com/org/declaragent"
-            target="_blank"
-            rel="noopener"
-            data-track="footer:npm"
-            >npm</a
-          >
-          <a
-            href="https://docs.declaragent.dev"
-            target="_blank"
-            rel="noopener"
-            data-track="footer:docs"
-            >Docs</a
-          >
-          <a
-            href="https://github.com/declaragent/declaragent/releases.atom"
-            target="_blank"
-            rel="noopener"
-            data-track="footer:rss"
-            >RSS</a
-          >
-          <a href="https://d9t.dev" data-track="footer:d9t">d9t.dev</a>
-        </div>
-        <div class="site-footer__legal">
-          <a
-            href="https://github.com/declaragent/declaragent/blob/main/LICENSE"
-            target="_blank"
-            rel="noopener"
-            >Apache-2.0</a
-          >
-          <span>&copy; 2026 Declaragent</span>
-        </div>
+        <nav class="site-footer__cols" aria-label="Footer">
+          <div>
+            <p class="site-footer__h">Docs</p>
+            <a href="https://docs.declaragent.dev/quickstart" target="_blank" rel="noopener" data-track="footer:quickstart">Quickstart</a>
+            <a href="https://docs.declaragent.dev/reference" target="_blank" rel="noopener" data-track="footer:reference">Reference</a>
+            <a href="https://docs.declaragent.dev/cookbook" target="_blank" rel="noopener" data-track="footer:cookbook">Cookbook</a>
+            <a href="https://docs.declaragent.dev/troubleshooting" target="_blank" rel="noopener" data-track="footer:troubleshooting">Troubleshooting</a>
+          </div>
+          <div>
+            <p class="site-footer__h">Project</p>
+            <a href="https://github.com/declaragent/declaragent" target="_blank" rel="noopener" data-track="footer:github">GitHub</a>
+            <a href="https://github.com/declaragent/declaragent/releases" target="_blank" rel="noopener" data-track="footer:releases">Changelog</a>
+            <a href="https://www.npmjs.com/org/declaragent" target="_blank" rel="noopener" data-track="footer:npm">npm</a>
+            <a href="https://github.com/declaragent/declaragent/blob/main/SECURITY.md" target="_blank" rel="noopener" data-track="footer:security">Security</a>
+          </div>
+          <div>
+            <p class="site-footer__h">Community</p>
+            <a href="https://github.com/declaragent/declaragent/discussions" target="_blank" rel="noopener" data-track="footer:discussions">Discussions</a>
+            <a href="https://github.com/declaragent/declaragent/issues" target="_blank" rel="noopener" data-track="footer:issues">Issues</a>
+          </div>
+        </nav>
+      </div>
+      <div class="site-footer__bar">
+        <span>© <span id="year">2026</span> Declaragent contributors · Apache-2.0</span>
+        <span class="site-footer__hint">no hidden console · no vendor dashboard · <code>git log</code> is the source of truth</span>
       </div>
     </footer>
 
-    <script type="module" src="/app.js?v=6"></script>
+    <script src="/app.js?v=7" defer></script>
   </body>
 </html>

--- a/website/styles.css
+++ b/website/styles.css
@@ -1,1757 +1,1130 @@
-/* ───────────────────────── design tokens ───────────────────────── */
+/* ============================================================================
+   Declaragent — declaragent.dev
+   Aesthetic: dark "audit-ledger / terminal instrument". Monospace-forward,
+   precision borders, line-number motifs, teal signature, ✓/◐/○ status system.
+   ========================================================================== */
+
 :root {
-  --bg: #0b0e14;
-  --bg-elev: #12161f;
-  --bg-elev-2: #1a1f2b;
-  --border: #242b3a;
-  --border-strong: #323a4d;
-  --fg: #e6eaf3;
-  --fg-muted: #9aa3b5;
-  --fg-dim: #6b7486;
-  --accent: #5eead4; /* teal */
-  --accent-strong: #2dd4bf;
-  --accent-dim: #0f766e;
-  --danger: #f87171;
-  --warn: #fbbf24;
+  --bg: #090b10;
+  --bg-1: #0d1018;
+  --bg-2: #131722;
+  --bg-3: #1a2030;
+  --line: #222a39;
+  --line-2: #2f3950;
+  --fg: #e9edf6;
+  --fg-muted: #98a1b4;
+  --fg-dim: #626b7e;
+
+  --accent: #5eead4;
+  --accent-2: #2dd4bf;
+  --accent-deep: #0b3b35;
+  --accent-ink: #021713;
+
   --ok: #4ade80;
-  --maxw: 1120px;
-  --radius: 12px;
-  --radius-lg: 18px;
-  --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
-  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
-  --shadow-lg: 0 12px 40px -8px rgb(0 0 0 / 0.5), 0 2px 8px rgb(0 0 0 / 0.25);
+  --warn: #f5b14b;
+  --dim: #6b7486;
+  --danger: #f87171;
+
+  --maxw: 1160px;
+  --radius: 10px;
+  --radius-lg: 16px;
+  --mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  --sans: "Inter", ui-sans-serif, system-ui, sans-serif;
+  --shadow: 0 18px 50px -18px rgb(0 0 0 / 0.7), 0 2px 8px rgb(0 0 0 / 0.4);
+  --glow: 0 0 0 1px rgb(94 234 212 / 0.18), 0 12px 40px -12px rgb(45 212 191 / 0.22);
 }
 
-/* ───────────────────────── reset ───────────────────────── */
-*,
-*::before,
-*::after {
+* {
   box-sizing: border-box;
 }
-html,
+
+html {
+  scroll-behavior: smooth;
+  -webkit-text-size-adjust: 100%;
+}
+
 body {
   margin: 0;
-  padding: 0;
-}
-body {
-  font-family: var(--font-sans);
   background: var(--bg);
   color: var(--fg);
-  line-height: 1.55;
+  font-family: var(--sans);
   font-size: 16px;
+  line-height: 1.6;
   -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
   overflow-x: hidden;
-}
-a {
-  color: inherit;
-  text-decoration: none;
-}
-button {
-  font: inherit;
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: inherit;
-}
-code,
-pre,
-kbd {
-  font-family: var(--font-mono);
-}
-code {
-  font-size: 0.92em;
-  color: var(--accent);
-  background: rgb(94 234 212 / 0.08);
-  padding: 0.12em 0.38em;
-  border-radius: 5px;
-  border: 1px solid rgb(94 234 212 / 0.15);
-}
-h1,
-h2,
-h3 {
-  margin: 0;
-  font-weight: 700;
-  letter-spacing: -0.022em;
-  line-height: 1.15;
+  /* atmosphere: faint terminal grid + a teal aurora behind the hero */
+  background-image: radial-gradient(900px 520px at 78% -8%, rgb(45 212 191 / 0.1), transparent 60%),
+    radial-gradient(700px 600px at -10% 0%, rgb(94 234 212 / 0.05), transparent 55%),
+    linear-gradient(transparent 0 95%, rgb(255 255 255 / 0.018) 95%),
+    linear-gradient(90deg, transparent 0 95%, rgb(255 255 255 / 0.018) 95%);
+  background-size: auto, auto, 38px 38px, 38px 38px;
+  background-attachment: fixed, fixed, fixed, fixed;
 }
 
-/* ───────────────────────── subtle grid background ───────────────────────── */
-body::before {
-  content: "";
+/* fine film-grain overlay for depth */
+.grain {
   position: fixed;
   inset: 0;
-  pointer-events: none;
-  background-image: linear-gradient(to right, rgb(94 234 212 / 0.035) 1px, transparent 1px),
-    linear-gradient(to bottom, rgb(94 234 212 / 0.035) 1px, transparent 1px);
-  background-size: 64px 64px;
-  mask-image: radial-gradient(ellipse at 50% 20%, black 0%, transparent 75%);
   z-index: 0;
+  pointer-events: none;
+  opacity: 0.5;
+  mix-blend-mode: overlay;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.4'/%3E%3C/svg%3E");
 }
 
-main > section,
+main,
 .site-header,
 .site-footer {
   position: relative;
   z-index: 1;
 }
 
-/* ───────────────────────── header ───────────────────────── */
-.site-header {
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+a:hover {
+  color: var(--accent-2);
+}
+code,
+pre,
+.mono {
+  font-family: var(--mono);
+}
+code {
+  font-size: 0.86em;
+  background: rgb(94 234 212 / 0.08);
+  border: 1px solid rgb(94 234 212 / 0.14);
+  color: #b8f5ea;
+  padding: 0.08em 0.4em;
+  border-radius: 5px;
+}
+::selection {
+  background: rgb(94 234 212 / 0.26);
+  color: #fff;
+}
+
+/* shared layout + section heads ------------------------------------------- */
+main > section {
   max-width: var(--maxw);
-  margin: 0 auto;
-  padding: 28px 28px 12px;
+  margin-inline: auto;
+  padding: clamp(56px, 8vw, 120px) clamp(20px, 5vw, 40px);
+  border-top: 1px solid var(--line);
+}
+main > section:first-child {
+  border-top: 0;
+}
+
+.sec__head {
+  max-width: 760px;
+  margin-bottom: 44px;
+}
+.sec__head--center {
+  margin-inline: auto;
+  text-align: center;
+}
+.sec__label {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  letter-spacing: 0.06em;
+  color: var(--accent);
+  margin: 0 0 14px;
+  font-weight: 600;
+}
+.sec__head h2 {
+  font-family: var(--mono);
+  font-weight: 800;
+  font-size: clamp(26px, 3.6vw, 40px);
+  line-height: 1.12;
+  letter-spacing: -0.02em;
+  margin: 0;
+}
+.muted-strong {
+  color: var(--accent);
+}
+.sec__sub {
+  color: var(--fg-muted);
+  margin: 16px 0 0;
+  font-size: 16.5px;
+}
+.nowrap {
+  white-space: nowrap;
+}
+
+/* dots / status atoms ----------------------------------------------------- */
+.dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  vertical-align: middle;
+}
+.dot--ok {
+  background: var(--ok);
+  box-shadow: 0 0 8px rgb(74 222 128 / 0.55);
+}
+.dot--warn {
+  background: var(--warn);
+  box-shadow: 0 0 8px rgb(245 177 75 / 0.5);
+}
+.dot--dim {
+  background: var(--dim);
+}
+
+/* buttons ----------------------------------------------------------------- */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--mono);
+  font-weight: 600;
+  font-size: 14px;
+  padding: 11px 18px;
+  border-radius: 8px;
+  cursor: pointer;
+  border: 1px solid var(--line-2);
+  background: transparent;
+  color: var(--fg);
+  transition: transform 0.12s ease, background 0.18s ease, border-color 0.18s ease, box-shadow 0.18s
+    ease;
+}
+.btn:hover {
+  transform: translateY(-2px);
+}
+.btn--lg {
+  padding: 14px 22px;
+  font-size: 15px;
+}
+.btn--accent {
+  background: var(--accent);
+  color: var(--accent-ink);
+  border-color: var(--accent);
+  box-shadow: 0 8px 24px -10px rgb(45 212 191 / 0.6);
+}
+.btn--accent:hover {
+  background: var(--accent-2);
+  color: var(--accent-ink);
+  box-shadow: 0 12px 30px -10px rgb(45 212 191 / 0.7);
+}
+.btn--ghost:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: rgb(94 234 212 / 0.06);
+}
+
+/* ===== HEADER ============================================================= */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 20px;
+  max-width: var(--maxw);
+  margin-inline: auto;
+  padding: 14px clamp(20px, 5vw, 40px);
+  backdrop-filter: blur(12px);
+  background: rgb(9 11 16 / 0.72);
+  border-bottom: 1px solid var(--line);
 }
 .brand {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 10px;
+  gap: 9px;
+  color: var(--fg);
   font-weight: 700;
-  font-size: 17px;
-  letter-spacing: -0.01em;
+}
+.brand__mark {
+  border-radius: 7px;
+  box-shadow: 0 0 18px -2px rgb(94 234 212 / 0.45);
+}
+.brand__name {
+  font-family: var(--mono);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  font-size: 16px;
+}
+.brand__alias {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--accent);
+  border: 1px solid rgb(94 234 212 / 0.3);
+  border-radius: 5px;
+  padding: 1px 6px;
+  margin-left: 2px;
+  opacity: 0.85;
 }
 .site-nav {
   display: flex;
   align-items: center;
-  gap: 26px;
-  font-size: 14.5px;
-  font-weight: 500;
-  color: var(--fg-muted);
-}
-.site-nav a:hover {
-  color: var(--fg);
-}
-.icon-link {
-  display: inline-flex;
-  align-items: center;
-  color: var(--fg-muted);
-}
-.icon-link:hover {
-  color: var(--accent);
-}
-
-/* ───────────────────────── hero ───────────────────────── */
-.hero {
-  max-width: var(--maxw);
-  margin: 0 auto;
-  padding: 72px 28px 80px;
-  display: grid;
-  grid-template-columns: 1.05fr 1fr;
-  gap: 56px;
-  align-items: center;
-}
-.eyebrow {
-  font-family: var(--font-mono);
-  font-size: 12.5px;
-  font-weight: 500;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--accent);
-  margin: 0 0 18px;
-}
-.hero h1 {
-  font-size: clamp(36px, 5vw, 64px);
-  line-height: 1.04;
-}
-.hero h1 .accent {
-  color: var(--accent);
-  background: linear-gradient(120deg, var(--accent) 0%, var(--accent-strong) 60%, #93c5fd 100%);
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-}
-.lede {
-  font-size: 18px;
-  color: var(--fg-muted);
-  max-width: 48ch;
-  margin: 24px 0 32px;
-}
-.lede--muted {
-  color: var(--fg-dim);
-}
-.hero__actions {
-  display: flex;
-  align-items: center;
-  gap: 14px;
-  flex-wrap: wrap;
-}
-.cmd {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  background: var(--bg-elev);
-  border: 1px solid var(--border);
-  padding: 14px 18px;
-  border-radius: 10px;
-  font-family: var(--font-mono);
-  font-size: 14px;
-  position: relative;
-  transition: border-color 0.2s, background 0.2s;
-}
-.cmd:hover,
-.cmd:focus-visible {
-  border-color: var(--accent-dim);
-  background: var(--bg-elev-2);
-  outline: none;
-}
-.cmd__prompt {
-  color: var(--accent);
-  user-select: none;
-}
-.cmd__copy {
-  margin-left: 8px;
-  color: var(--fg-dim);
-  font-size: 13px;
-  transition: color 0.15s;
-}
-.cmd.copied .cmd__copy {
-  color: var(--ok);
-}
-.cmd.copied .cmd__copy::after {
-  content: "  copied";
-}
-
-.btn {
-  display: inline-flex;
-  align-items: center;
-  padding: 13px 22px;
-  border-radius: 10px;
-  font-weight: 600;
-  font-size: 14.5px;
-  border: 1px solid transparent;
-  transition: background 0.15s, border-color 0.15s, color 0.15s;
-  cursor: pointer;
-  font-family: inherit;
-}
-.btn--accent {
-  background: var(--accent);
-  color: var(--bg);
-  border-color: var(--accent);
-}
-.btn--accent:hover {
-  background: var(--accent-strong);
-  border-color: var(--accent-strong);
-}
-.btn--ghost {
-  background: transparent;
-  color: var(--fg);
-  border-color: var(--border-strong);
-}
-.btn--ghost:hover {
-  background: var(--bg-elev);
-  border-color: var(--accent-dim);
-}
-
-.hero__meta {
-  margin-top: 24px;
-  font-family: var(--font-mono);
-  font-size: 12.5px;
-  color: var(--fg-dim);
-}
-
-/* ───────────────────────── hero terminal ───────────────────────── */
-.hero__terminal {
-  width: 100%;
-}
-.term {
-  background: var(--bg-elev);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-lg);
-  overflow: hidden;
-  font-family: var(--font-mono);
-}
-.term__chrome {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 14px;
-  background: var(--bg-elev-2);
-  border-bottom: 1px solid var(--border);
-}
-.term__dot {
-  width: 11px;
-  height: 11px;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-.term__dot--r {
-  background: #ff5f56;
-}
-.term__dot--y {
-  background: #ffbd2e;
-}
-.term__dot--g {
-  background: #27c93f;
-}
-.term__title {
-  margin-left: 12px;
-  font-size: 11.5px;
-  color: var(--fg-dim);
-  letter-spacing: 0.02em;
-}
-.term__body {
-  margin: 0;
-  padding: 18px 20px 22px;
-  font-size: 12.5px;
-  line-height: 1.55;
-  min-height: 380px;
-  max-height: 480px;
-  overflow: hidden;
-  color: var(--fg);
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-.term__cursor {
-  display: inline-block;
-  color: var(--accent);
-  animation: term-blink 1s step-end infinite;
-  margin-left: 1px;
-}
-.term__body .prompt {
-  color: var(--accent);
-  font-weight: 700;
-}
-.term__body .cmd {
-  color: var(--fg);
-}
-.term__body .ok {
-  color: var(--ok);
-}
-.term__body .dim {
-  color: var(--fg-dim);
-}
-.term__body .warn {
-  color: var(--warn);
-}
-.term__body .key {
-  color: #93c5fd;
-}
-.term__body .str {
-  color: #fcd34d;
-}
-@keyframes term-blink {
-  50% {
-    opacity: 0;
-  }
-}
-
-kbd {
-  display: inline-block;
-  padding: 2px 8px;
-  border-radius: 5px;
-  background: var(--bg-elev-2);
-  border: 1px solid var(--border);
-  border-bottom-width: 2px;
-  font-size: 11px;
-  color: var(--fg-muted);
-}
-
-/* ───────────────────────── meta — built with itself ───────────────────────── */
-.meta {
-  max-width: var(--maxw);
-  margin: 0 auto;
-  padding: 24px 28px 56px;
-}
-.meta__inner {
-  background: linear-gradient(180deg, var(--bg-elev) 0%, var(--bg) 100%);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: 40px 40px 32px;
-  box-shadow: var(--shadow-lg);
-}
-.meta__inner h2 {
-  font-size: clamp(26px, 3.2vw, 36px);
-  margin: 16px 0 14px;
-  letter-spacing: -0.02em;
-}
-.meta__inner h2 code {
-  font-size: 0.95em;
-  color: var(--accent);
-  background: rgb(94 234 212 / 0.1);
-  border: 1px solid rgb(94 234 212 / 0.25);
-  padding: 0.12em 0.45em;
-  border-radius: 6px;
-}
-.meta__inner .lede {
-  font-size: 16px;
-  max-width: 62ch;
-  margin: 0 0 32px;
-}
-.meta__flow {
-  display: flex;
-  align-items: stretch;
-  gap: 10px;
-  margin: 0 0 24px;
-  overflow-x: auto;
-  padding: 4px 0 14px;
-}
-.meta__node {
-  flex: 1 1 0;
-  min-width: 220px;
-  background: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  padding: 14px 16px 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  transition: border-color 0.2s;
-}
-.meta__node:hover {
-  border-color: var(--accent-dim);
-}
-.meta__node--core {
-  border-color: var(--accent-dim);
-  background: rgb(94 234 212 / 0.04);
-}
-.meta__node-tag {
-  font-family: var(--font-mono);
-  font-size: 10.5px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--accent);
-}
-.meta__node-title {
-  font-family: var(--font-mono);
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--fg);
-}
-.meta__node-sub {
-  font-size: 12.5px;
-  color: var(--fg-muted);
-  line-height: 1.45;
-}
-.meta__arrow {
-  width: 42px;
-  flex-shrink: 0;
-  align-self: center;
-  color: var(--fg-dim);
-}
-.meta__foot {
-  margin: 0;
-  font-size: 14px;
-  color: var(--fg-muted);
-  line-height: 1.6;
-  max-width: 64ch;
-  border-top: 1px solid var(--border);
-  padding-top: 22px;
-}
-.meta__cta {
-  margin-top: 22px;
-}
-
-/* ───────────────────────── capabilities grid ───────────────────────── */
-.caps {
-  max-width: var(--maxw);
-  margin: 0 auto;
-  padding: 60px 28px 40px;
-}
-.caps__header {
-  max-width: 760px;
-  margin-bottom: 42px;
-}
-.caps__header h2 {
-  font-size: clamp(28px, 3.5vw, 44px);
-  margin-bottom: 16px;
-}
-.caps__grid {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 16px;
-}
-.cap {
-  background: var(--bg-elev);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 22px 22px 20px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  transition: border-color 0.2s, transform 0.2s;
-  min-height: 100%;
-}
-.cap:hover {
-  border-color: var(--accent-dim);
-  transform: translateY(-2px);
-}
-.cap__head {
-  display: flex;
-  flex-direction: column;
   gap: 6px;
 }
-.cap__tag {
-  align-self: flex-start;
-  font-family: var(--font-mono);
-  font-size: 10.5px;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--accent);
-  background: rgb(94 234 212 / 0.1);
-  border: 1px solid rgb(94 234 212 / 0.2);
-  padding: 3px 8px;
-  border-radius: 5px;
-}
-.cap h3 {
-  font-size: 16px;
-  margin: 0;
-  letter-spacing: -0.01em;
-}
-.cap p {
-  margin: 0;
+.site-nav > a {
+  font-family: var(--mono);
   font-size: 13.5px;
-  line-height: 1.55;
   color: var(--fg-muted);
-  flex: 1;
-}
-.cap__code {
-  background: var(--bg);
-  border: 1px solid var(--border);
+  padding: 7px 11px;
   border-radius: 7px;
-  padding: 10px 12px;
-  margin: 4px 0 0;
-  font-size: 11.5px;
-  line-height: 1.55;
+  transition: color 0.15s, background 0.15s;
+}
+.site-nav > a:hover {
   color: var(--fg);
-  white-space: pre;
-  overflow-x: auto;
+  background: rgb(255 255 255 / 0.04);
 }
-.cap__code code {
-  background: transparent;
-  color: inherit;
-  border: none;
-  padding: 0;
-  font-size: inherit;
-}
-.cap__link {
-  font-family: var(--font-mono);
-  font-size: 12px;
-  color: var(--accent);
-  transition: color 0.15s;
-  align-self: flex-start;
-  margin-top: 4px;
-}
-.cap__link:hover {
-  color: var(--accent-strong);
-}
-
-/* ───────────────────────── CLI lifecycle ───────────────────────── */
-.lifecycle {
-  max-width: var(--maxw);
-  margin: 0 auto;
-  padding: 60px 28px;
-}
-.lifecycle__header {
-  max-width: 760px;
-  margin-bottom: 42px;
-}
-.lifecycle__header h2 {
-  font-size: clamp(28px, 3.5vw, 44px);
-  margin-bottom: 16px;
-}
-.lifecycle__grid {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 16px;
-}
-.stage {
-  background: var(--bg-elev);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 24px 22px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  transition: border-color 0.2s;
-}
-.stage:hover {
-  border-color: var(--accent-dim);
-}
-.stage__num {
-  font-family: var(--font-mono);
-  font-size: 12px;
-  color: var(--accent);
-  letter-spacing: 0.08em;
-}
-.stage h3 {
-  font-size: 20px;
-  margin: 0;
-}
-.stage__code {
-  background: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 14px;
-  margin: 0;
-  font-size: 11.5px;
-  line-height: 1.55;
-  color: var(--fg);
-  white-space: pre;
-  overflow-x: auto;
-}
-.stage__code code {
-  background: transparent;
-  color: inherit;
-  border: none;
-  padding: 0;
-  font-size: inherit;
-}
-.stage p {
-  margin: 0;
-  font-size: 13.5px;
-  color: var(--fg-muted);
-  line-height: 1.55;
-}
-
-/* ───────────────────────── enterprise primitives ───────────────────────── */
-.ent {
-  max-width: var(--maxw);
-  margin: 0 auto;
-  padding: 60px 28px;
-}
-.ent__header {
-  max-width: 760px;
-  margin-bottom: 36px;
-}
-.ent__header h2 {
-  font-size: clamp(28px, 3.5vw, 40px);
-}
-.ent__grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 16px;
-}
-.ent-card {
-  background: var(--bg-elev);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 26px 28px;
-  transition: border-color 0.2s;
-}
-.ent-card:hover {
-  border-color: var(--accent-dim);
-}
-.ent-card h3 {
-  font-size: 18px;
-  margin-bottom: 10px;
-  color: var(--accent);
-}
-.ent-card p {
-  margin: 0;
-  color: var(--fg-muted);
-  font-size: 14px;
-  line-height: 1.65;
-}
-
-/* ───────────────────────── validator ───────────────────────── */
-.validator {
-  max-width: var(--maxw);
-  margin: 0 auto;
-  padding: 60px 28px;
-}
-.validator__header {
-  max-width: 780px;
-  margin-bottom: 36px;
-}
-.validator__header h2 {
-  font-size: clamp(28px, 3.5vw, 40px);
-  margin-bottom: 18px;
-}
-.validator__grid {
-  display: grid;
-  grid-template-columns: 1.1fr 1fr;
-  gap: 20px;
-  min-height: 440px;
-}
-.editor {
-  background: var(--bg-elev);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-}
-.editor__tab {
-  padding: 10px 16px;
-  font-family: var(--font-mono);
-  font-size: 12.5px;
-  color: var(--fg-muted);
-  border-bottom: 1px solid var(--border);
-  background: var(--bg-elev-2);
-}
-#yaml-input {
-  flex: 1;
-  min-height: 380px;
-  resize: vertical;
-  border: none;
-  padding: 18px;
-  font-family: var(--font-mono);
-  font-size: 13.5px;
-  line-height: 1.65;
-  color: var(--fg);
-  background: transparent;
-  outline: none;
-  tab-size: 2;
-  white-space: pre;
-  overflow-wrap: normal;
-  overflow-x: auto;
-}
-
-.findings {
-  background: var(--bg-elev);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-}
-.findings__header {
-  display: flex;
+.star-pill {
+  display: inline-flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 12px 16px;
-  background: var(--bg-elev-2);
-  border-bottom: 1px solid var(--border);
-}
-.findings__title {
-  font-family: var(--font-mono);
-  font-size: 12.5px;
-  color: var(--fg-muted);
-}
-.findings__list {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  overflow-y: auto;
-  flex: 1;
-}
-.findings__placeholder,
-.finding {
-  padding: 16px 18px;
-  font-family: var(--font-mono);
-  font-size: 13px;
-  line-height: 1.6;
-  border-bottom: 1px solid var(--border);
-  display: flex;
-  gap: 14px;
-  align-items: flex-start;
-}
-.findings__placeholder {
-  color: var(--fg-dim);
-  font-style: italic;
-}
-.finding__tag {
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  padding: 3px 8px;
-  border-radius: 4px;
-  flex-shrink: 0;
-  line-height: 1.4;
-  margin-top: 2px;
-  text-transform: uppercase;
-}
-.finding--ok .finding__tag {
-  background: rgb(74 222 128 / 0.15);
-  color: var(--ok);
-}
-.finding--warn .finding__tag {
-  background: rgb(251 191 36 / 0.15);
-  color: var(--warn);
-}
-.finding--error .finding__tag {
-  background: rgb(248 113 113 / 0.15);
-  color: var(--danger);
-}
-.finding__body {
-  flex: 1;
-  min-width: 0;
-}
-.finding__code {
+  gap: 7px;
+  color: var(--accent-ink) !important;
+  background: var(--accent);
   font-weight: 600;
-  color: var(--fg);
-  margin-bottom: 2px;
+  box-shadow: 0 6px 18px -8px rgb(45 212 191 / 0.7);
 }
-.finding--ok .finding__code {
-  color: var(--ok);
-}
-.finding--warn .finding__code {
-  color: var(--warn);
-}
-.finding--error .finding__code {
-  color: var(--danger);
-}
-.finding__msg {
-  color: var(--fg-muted);
-  word-break: break-word;
+.star-pill:hover {
+  background: var(--accent-2);
 }
 
-/* ───────────────────────── install ───────────────────────── */
+/* ===== HERO =============================================================== */
+.hero {
+  display: grid;
+  grid-template-columns: 1.05fr 0.95fr;
+  gap: clamp(28px, 5vw, 60px);
+  align-items: center;
+  padding-top: clamp(48px, 7vw, 96px) !important;
+}
+.kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  font-family: var(--mono);
+  font-size: 12.5px;
+  color: var(--fg-muted);
+  letter-spacing: 0.02em;
+  margin: 0 0 22px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 6px 14px;
+  background: var(--bg-1);
+}
+.kicker__sq {
+  width: 7px;
+  height: 7px;
+  background: var(--accent);
+  border-radius: 2px;
+  box-shadow: 0 0 8px var(--accent);
+}
+.hero h1 {
+  font-family: var(--mono);
+  font-weight: 800;
+  font-size: clamp(34px, 6vw, 62px);
+  line-height: 1.04;
+  letter-spacing: -0.035em;
+  margin: 0 0 22px;
+}
+.hero h1 code {
+  background: none;
+  border: none;
+  padding: 0;
+  color: inherit;
+  font-size: inherit;
+}
+.hero__accent {
+  color: var(--accent);
+}
+.hero__accent code {
+  color: var(--accent);
+}
+.hero__sub {
+  color: var(--fg-muted);
+  font-size: clamp(16px, 1.5vw, 18.5px);
+  max-width: 540px;
+  margin: 0 0 30px;
+}
+.hero__sub code {
+  font-size: 0.9em;
+}
+
 .install {
-  padding: 80px 28px 60px;
-  background: radial-gradient(ellipse at 50% 0%, rgb(94 234 212 / 0.08) 0%, transparent 60%);
-}
-.install__inner {
-  max-width: 720px;
-  margin: 0 auto;
-  text-align: center;
-}
-.install__inner h2 {
-  font-size: clamp(32px, 4vw, 52px);
-  margin-bottom: 28px;
+  max-width: 540px;
 }
 .install__tabs {
   display: inline-flex;
-  gap: 2px;
-  background: var(--bg-elev);
-  border: 1px solid var(--border);
-  border-radius: 10px;
+  gap: 4px;
+  margin-bottom: 10px;
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: 9px;
   padding: 4px;
-  margin-bottom: 14px;
 }
 .install__tab {
-  padding: 7px 16px;
-  border-radius: 7px;
-  font-family: var(--font-mono);
-  font-size: 13px;
+  font-family: var(--mono);
+  font-size: 12.5px;
   color: var(--fg-muted);
+  background: none;
+  border: 0;
+  padding: 5px 13px;
+  border-radius: 6px;
+  cursor: pointer;
   transition: color 0.15s, background 0.15s;
 }
 .install__tab:hover {
   color: var(--fg);
 }
 .install__tab.is-active {
-  background: var(--bg-elev-2);
-  color: var(--accent);
+  color: var(--accent-ink);
+  background: var(--accent);
+  font-weight: 600;
 }
-.install__block {
-  background: var(--bg-elev);
-  border: 1px solid var(--border-strong);
-  border-radius: 12px;
-  padding: 22px 24px;
+.install__cmd {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  width: 100%;
+  font-family: var(--mono);
+  font-size: 14.5px;
   text-align: left;
-  font-size: 14px;
-  line-height: 1.7;
-  margin: 0 0 22px;
+  background: var(--bg-1);
+  border: 1px solid var(--line-2);
+  color: var(--fg);
+  border-radius: 11px;
+  padding: 15px 16px;
+  cursor: pointer;
+  transition: border-color 0.18s, box-shadow 0.18s;
 }
-.install__block[hidden] {
+.install__cmd:hover {
+  border-color: var(--accent);
+  box-shadow: var(--glow);
+}
+.install__prompt {
+  color: var(--accent);
+  font-weight: 700;
+}
+.install__panels {
+  flex: 1;
+}
+.install__panels > span[hidden] {
   display: none;
 }
-.install__block--sub {
-  border-color: var(--border);
-  margin-top: 8px;
-}
-.install__then {
-  font-family: var(--font-mono);
-  font-size: 12.5px;
-  color: var(--fg-dim);
-  margin: 8px 0 8px;
-  text-align: left;
+.install__copy {
+  font-size: 11px;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
+  color: var(--fg-dim);
+  border: 1px solid var(--line-2);
+  border-radius: 6px;
+  padding: 4px 9px;
+  transition: color 0.15s, border-color 0.15s;
+}
+.install__cmd:hover .install__copy {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.install__cmd.copied .install__copy {
+  color: var(--ok);
+  border-color: var(--ok);
+}
+.install__cmd.copied .install__copy {
+  font-size: 0;
+}
+.install__cmd.copied .install__copy::after {
+  content: "copied ✓";
+  font-size: 11px;
   letter-spacing: 0.08em;
 }
-.install__block code {
-  background: transparent;
+.hero__meta {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  color: var(--fg-dim);
+  margin: 16px 0 0;
+  line-height: 1.9;
+}
+
+/* terminal card */
+.terminal {
+  background: linear-gradient(180deg, var(--bg-2), var(--bg-1));
+  border: 1px solid var(--line-2);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+  min-height: 360px;
+  display: flex;
+  flex-direction: column;
+}
+.terminal__bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 11px 14px;
+  border-bottom: 1px solid var(--line);
+  background: rgb(255 255 255 / 0.02);
+}
+.terminal__dots {
+  display: inline-flex;
+  gap: 7px;
+}
+.terminal__dots i {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: var(--line-2);
+}
+.terminal__dots i:nth-child(1) {
+  background: #ff5f57;
+}
+.terminal__dots i:nth-child(2) {
+  background: #febc2e;
+}
+.terminal__dots i:nth-child(3) {
+  background: #28c840;
+}
+.terminal__title {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--fg-dim);
+  flex: 1;
+  text-align: center;
+}
+.terminal__skip {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--fg-dim);
+  background: none;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 3px 8px;
+  cursor: pointer;
+}
+.terminal__skip:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.terminal__screen {
+  margin: 0;
+  padding: 16px 18px;
+  flex: 1;
+  overflow: auto;
+  font-family: var(--mono);
+  font-size: 12.6px;
+  line-height: 1.72;
   color: var(--fg);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 460px;
+}
+.terminal__cursor {
+  color: var(--accent);
+  animation: blink 1.1s steps(2) infinite;
+}
+@keyframes blink {
+  50% {
+    opacity: 0;
+  }
+}
+/* terminal token colors (emitted by app.js typer) */
+#term-body .prompt {
+  color: var(--accent);
+  font-weight: 700;
+}
+#term-body .cmd {
+  color: var(--fg);
+  font-weight: 600;
+}
+#term-body .ok {
+  color: var(--ok);
+}
+#term-body .dim {
+  color: var(--fg-dim);
+}
+#term-body .warn {
+  color: var(--warn);
+}
+#term-body .key {
+  color: #8bd3ff;
+}
+#term-body .str {
+  color: #f3c98b;
+}
+
+/* ===== HOW / DECLARATIVE LOOP ============================================ */
+.loop {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+}
+.loop__step {
+  position: relative;
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  padding: 26px 22px 22px;
+  transition: border-color 0.2s, transform 0.2s;
+}
+.loop__step:hover {
+  border-color: var(--line-2);
+  transform: translateY(-3px);
+}
+.loop__n {
+  font-family: var(--mono);
+  font-weight: 800;
+  font-size: 13px;
+  color: var(--accent);
+  border: 1px solid rgb(94 234 212 / 0.3);
+  border-radius: 7px;
+  padding: 3px 9px;
+  background: rgb(94 234 212 / 0.06);
+}
+.loop__step h3 {
+  font-family: var(--mono);
+  font-size: 18px;
+  margin: 16px 0 8px;
+  letter-spacing: -0.01em;
+}
+.loop__step p {
+  color: var(--fg-muted);
+  font-size: 14.5px;
+  margin: 0 0 16px;
+}
+.loop__code {
+  margin: 0;
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  padding: 12px 13px;
+  font-size: 12px;
+  line-height: 1.65;
+  color: var(--fg);
+  overflow: auto;
+}
+.loop__code code {
+  background: none;
   border: none;
   padding: 0;
-  font-size: inherit;
-  white-space: pre;
+  color: inherit;
+  font-size: 12px;
 }
-.install__links {
+.c-dim {
+  color: var(--fg-dim);
+}
+.c-ok {
+  color: var(--ok);
+}
+
+.lifecycle {
+  margin-top: 28px;
   display: flex;
-  gap: 14px;
-  justify-content: center;
   flex-wrap: wrap;
-}
-
-/* ───────────────────────── footer ───────────────────────── */
-.site-footer {
-  border-top: 1px solid var(--border);
-  padding: 36px 28px 48px;
-  margin-top: 40px;
-}
-.site-footer__inner {
-  max-width: var(--maxw);
-  margin: 0 auto;
-  display: grid;
-  grid-template-columns: 1fr auto auto;
-  gap: 28px;
   align-items: center;
-  font-size: 13.5px;
-  color: var(--fg-muted);
+  gap: 14px 18px;
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 16px 20px;
 }
-.site-footer__brand {
-  display: flex;
-  flex-direction: column;
-}
-.site-footer__brand span:first-child {
-  font-weight: 700;
-  font-size: 15px;
-  color: var(--fg);
-  letter-spacing: -0.01em;
-}
-.site-footer__tagline {
-  color: var(--fg-dim);
-  font-size: 13px;
-  margin-top: 3px;
-}
-.site-footer__links {
-  display: flex;
-  gap: 22px;
-}
-.site-footer__links a:hover {
-  color: var(--fg);
-}
-.site-footer__legal {
-  display: flex;
-  gap: 14px;
-  font-family: var(--font-mono);
-  font-size: 12px;
-  color: var(--fg-dim);
-}
-
-/* ──────────────────────────────────────────────────────────────────
-   DESIGN SYSTEM v2 — "Receipts-first"
-   ──────────────────────────────────────────────────────────────────
-   Thesis: evidence-based honesty is the brand. Status chips (✓ / ◐ /
-   ○) and receipt pills (file:line refs, commit SHAs) are first-class
-   visual elements. Every major claim carries a receipt.
-
-   Kept from v1: dark palette, teal accent, JetBrains Mono + Inter,
-   subtle grid bg, radius + shadow tokens. Extensions below.
-   ────────────────────────────────────────────────────────────────── */
-
-/* ───── brand alias pill (d9t) in nav ───── */
-.brand {
-  position: relative;
-}
-.brand__alias {
-  font-family: var(--font-mono);
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--fg-dim);
-  padding-left: 10px;
-  margin-left: 2px;
-  letter-spacing: 0.02em;
-  border-left: 1px solid var(--border);
-  transition: color 0.2s;
-}
-.brand:hover .brand__alias {
-  color: var(--accent);
-}
-.brand__alias-dot {
-  display: none;
-}
-.brand__alias-inline {
-  display: inline-block;
-  padding: 2px 8px;
-  border: 1px solid var(--border);
-  border-radius: 5px;
-  font-family: var(--font-mono);
-  font-size: 10.5px;
-  color: var(--fg-dim);
-  letter-spacing: 0.1em;
+.lifecycle__label {
+  font-family: var(--mono);
+  font-size: 11.5px;
   text-transform: uppercase;
-  margin-right: 4px;
-  vertical-align: 1px;
-}
-
-/* ───── star pill in nav ───── */
-.star-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  padding: 7px 14px;
-  border-radius: 999px;
-  background: var(--bg-elev);
-  border: 1px solid var(--border-strong);
-  font-family: var(--font-mono);
-  font-size: 12.5px;
-  font-weight: 600;
-  color: var(--fg);
-  letter-spacing: 0.02em;
-  transition: border-color 0.15s, background 0.15s, color 0.15s, transform 0.15s;
-}
-.star-pill:hover {
-  border-color: var(--accent);
-  background: var(--bg-elev-2);
-  color: var(--accent);
-  transform: translateY(-1px);
-}
-.star-pill svg {
-  transition: transform 0.2s;
-}
-.star-pill:hover svg {
-  transform: rotate(-8deg) scale(1.08);
-}
-.star-pill__divider {
+  letter-spacing: 0.1em;
   color: var(--fg-dim);
 }
-.star-pill__label {
-  color: var(--fg-muted);
-  font-weight: 500;
-}
-
-/* ───── hero extensions ───── */
-.eyebrow {
+.lifecycle__chain {
   display: inline-flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 8px;
-  flex-wrap: wrap;
+  font-family: var(--mono);
+  font-size: 13px;
 }
-.eyebrow__pill {
+.lifecycle__chain code {
+  background: var(--bg-3);
+  border-color: var(--line-2);
+  color: #c9f7ee;
+}
+.lifecycle__chain span {
+  color: var(--fg-dim);
+}
+
+/* ===== CAPABILITIES ====================================================== */
+.caps__grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+.cap {
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  padding: 22px 20px;
+  transition: border-color 0.2s, transform 0.2s, box-shadow 0.2s;
+}
+.cap:hover {
+  border-color: rgb(94 234 212 / 0.4);
+  transform: translateY(-3px);
+  box-shadow: var(--glow);
+}
+.cap h3 {
+  font-family: var(--mono);
+  font-size: 16px;
+  margin: 0 0 14px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  letter-spacing: -0.01em;
+}
+.cap__i {
+  display: inline-grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
   background: rgb(94 234 212 / 0.1);
   border: 1px solid rgb(94 234 212 / 0.25);
-  padding: 2px 9px;
-  border-radius: 5px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-}
-.eyebrow__sep {
-  color: var(--fg-dim);
-}
-.eyebrow__link {
-  color: var(--fg-muted);
-  text-decoration: underline;
-  text-decoration-color: var(--border-strong);
-  text-underline-offset: 3px;
-  transition: color 0.15s, text-decoration-color 0.15s;
-}
-.eyebrow__link:hover {
+  border-radius: 8px;
   color: var(--accent);
-  text-decoration-color: var(--accent);
+  font-size: 15px;
 }
-
-.hero h1 .strike {
+.cap ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 9px;
+}
+.cap li {
+  font-size: 13.5px;
+  color: var(--fg-muted);
+  padding-left: 16px;
   position: relative;
-  white-space: nowrap;
-  color: var(--fg);
+  line-height: 1.5;
 }
-.hero h1 .strike::after {
-  content: "";
+.cap li::before {
+  content: "›";
   position: absolute;
-  left: -2%;
-  right: -2%;
-  top: 52%;
-  height: 3px;
-  background: var(--accent);
-  transform: rotate(-3deg);
-  border-radius: 2px;
-  opacity: 0.9;
+  left: 0;
+  color: var(--accent);
 }
-.h1-code {
-  font-size: 0.78em;
-  padding: 0.06em 0.32em 0.1em !important;
-  vertical-align: 0.08em;
-  background: rgb(94 234 212 / 0.14) !important;
-  border: 1px solid rgb(94 234 212 / 0.35) !important;
-  color: var(--accent) !important;
-  -webkit-text-fill-color: var(--accent);
+.cap li b {
+  color: var(--fg);
+  font-weight: 600;
+}
+.cap li code {
+  font-size: 11.5px;
 }
 
-.hero__short {
-  margin: 14px 0 0;
-  font-family: var(--font-mono);
+/* ===== HONEST STATUS LEDGER (centerpiece) =============================== */
+.status {
+  background: radial-gradient(700px 360px at 50% -10%, rgb(45 212 191 / 0.06), transparent 65%);
+}
+.legend {
+  font-family: var(--mono);
+  font-weight: 600;
   font-size: 12.5px;
+  color: var(--fg-muted);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0 6px;
+}
+
+.ledger {
+  border: 1px solid var(--line-2);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  background: var(--bg-1);
+  box-shadow: var(--shadow);
+  max-width: 940px;
+  margin: 0 auto;
+}
+.ledger__row {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr 1.6fr;
+  align-items: center;
+  gap: 14px;
+  padding: 16px 22px;
+  border-top: 1px solid var(--line);
+  transition: background 0.15s;
+}
+.ledger__row:first-child {
+  border-top: 0;
+}
+.ledger__row:not(.ledger__row--head):hover {
+  background: rgb(255 255 255 / 0.022);
+}
+.ledger__row--head {
+  background: var(--bg-2);
+  font-family: var(--mono);
+  font-size: 11.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
   color: var(--fg-dim);
 }
-
-/* ───── stat row (receipts under hero) ───── */
-.stat-row {
-  list-style: none;
-  margin: 28px 0 0;
-  padding: 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0;
-  border-top: 1px solid var(--border);
-  border-bottom: 1px solid var(--border);
+.ledger__grade-h {
+  color: var(--accent);
 }
-.stat {
-  flex: 1 1 0;
-  min-width: 120px;
-  padding: 14px 18px;
-  border-right: 1px solid var(--border);
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-}
-.stat:last-child {
-  border-right: none;
-}
-.stat__value {
-  font-family: var(--font-mono);
-  font-size: 19px;
+.ledger__pillar b {
+  display: block;
+  font-family: var(--mono);
+  font-size: 15px;
   font-weight: 700;
   color: var(--fg);
   letter-spacing: -0.01em;
-  display: inline-flex;
-  align-items: baseline;
-  gap: 6px;
 }
-.stat__label {
-  font-size: 12px;
-  color: var(--fg-dim);
-  letter-spacing: 0.03em;
-  white-space: nowrap;
-}
-.stat__mark {
-  font-family: var(--font-mono);
-  font-weight: 700;
-  font-size: 0.85em;
-}
-.stat__mark--ok {
-  color: var(--ok);
-}
-
-/* ───── terminal: skip button ───── */
-.term__chrome {
-  position: relative;
-}
-.term__skip {
-  position: absolute;
-  right: 10px;
-  top: 8px;
-  font-family: var(--font-mono);
-  font-size: 10.5px;
-  color: var(--fg-dim);
-  padding: 4px 10px;
-  border-radius: 5px;
-  border: 1px solid var(--border);
-  background: var(--bg-elev);
-  transition: color 0.15s, border-color 0.15s;
-  letter-spacing: 0.04em;
-}
-.term__skip:hover {
-  color: var(--accent);
-  border-color: var(--accent-dim);
-}
-.term__skip[hidden] {
-  display: none;
-}
-
-/* ───── receipts + status chips — the brand's visual signature ───── */
-.receipt {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 3px 9px;
-  border-radius: 5px;
-  background: rgb(74 222 128 / 0.08);
-  border: 1px solid rgb(74 222 128 / 0.22);
-  font-family: var(--font-mono);
-  font-size: 11.5px;
-  color: var(--fg-muted);
-  margin-right: 10px;
-  vertical-align: 2px;
-}
-.receipt__ok {
-  color: var(--ok);
-  font-weight: 700;
-}
-.receipt code {
-  background: transparent !important;
-  border: none !important;
-  padding: 0 !important;
-  font-size: inherit !important;
-  color: var(--fg-muted) !important;
-  -webkit-text-fill-color: var(--fg-muted);
-}
-
-.status {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  padding: 3px 9px;
-  border-radius: 5px;
-  font-family: var(--font-mono);
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: none;
-  white-space: nowrap;
-}
-.status--ok {
-  background: rgb(74 222 128 / 0.1);
-  border: 1px solid rgb(74 222 128 / 0.3);
-  color: var(--ok);
-}
-.status--wip {
-  background: rgb(251 191 36 / 0.08);
-  border: 1px solid rgb(251 191 36 / 0.28);
-  color: var(--warn);
-}
-.status--todo {
-  background: rgb(107 116 134 / 0.08);
-  border: 1px solid var(--border-strong);
-  color: var(--fg-muted);
-}
-.status-pair {
-  display: inline-flex;
-  gap: 6px;
-  flex-wrap: wrap;
-  margin-left: 4px;
-  vertical-align: 4px;
-}
-.status-inline {
-  font-family: var(--font-mono);
-  font-weight: 700;
-  font-size: 0.92em;
-  padding: 0 2px;
-}
-.status-inline--ok {
-  color: var(--ok);
-}
-.status-inline--wip {
-  color: var(--warn);
-}
-
-.receipt-link {
-  font-family: var(--font-mono);
-  font-size: 11.5px;
-  color: var(--accent);
-  letter-spacing: 0.02em;
-  transition: color 0.15s;
-}
-.receipt-link:hover {
-  color: var(--accent-strong);
-}
-
-/* ───── pillar cards (honest status) ───── */
-.pillar {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-  position: relative;
-}
-.pillar__head {
-  display: flex;
-  align-items: baseline;
-  gap: 12px;
-}
-.pillar__num {
-  font-family: var(--font-mono);
-  font-size: 13px;
-  font-weight: 700;
-  color: var(--accent);
-  letter-spacing: 0.06em;
-}
-.pillar__head h3 {
-  font-size: 17px;
-  color: var(--fg);
-  margin: 0;
-}
-.pillar p {
-  flex: 1;
-  margin: 0;
-  font-size: 13.5px;
-  line-height: 1.6;
-  color: var(--fg-muted);
-}
-.pillar__foot {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  align-items: center;
-  padding-top: 14px;
-  border-top: 1px solid var(--border);
-}
-.pillar__foot .receipt-link {
-  margin-left: auto;
-}
-.pillar--honesty {
-  background: linear-gradient(180deg, var(--bg-elev) 0%, var(--bg) 100%);
-  border-color: var(--accent-dim);
-}
-.pillar--honesty .pillar__num {
-  color: var(--ok);
-}
-
-/* ───── "not yet" rail — the award-winning move ───── */
-.notyet {
-  margin-top: 32px;
-  background: linear-gradient(180deg, rgb(251 191 36 / 0.04) 0%, rgb(11 14 20 / 0) 100%);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: 28px 32px 24px;
-  position: relative;
-  overflow: hidden;
-}
-.notyet::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background-image: repeating-linear-gradient(
-    135deg,
-    transparent 0 10px,
-    rgb(251 191 36 / 0.025) 10px 11px
-  );
-}
-.notyet__eyebrow {
-  font-family: var(--font-mono);
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--warn);
-  margin: 0 0 18px;
-  position: relative;
-}
-.notyet__list {
-  list-style: none;
-  margin: 0 0 20px;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  position: relative;
-}
-.notyet__item {
-  display: grid;
-  grid-template-columns: 24px 1.4fr 2fr auto;
-  gap: 14px;
-  align-items: baseline;
-  padding: 12px 4px;
-  border-bottom: 1px dashed var(--border);
-  font-size: 13.5px;
-}
-.notyet__item:last-child {
-  border-bottom: none;
-}
-.notyet__mark {
-  font-family: var(--font-mono);
-  font-weight: 700;
-  color: var(--warn);
-  font-size: 15px;
-}
-.notyet__title {
-  font-weight: 600;
-  color: var(--fg);
-}
-.notyet__gap {
-  color: var(--fg-muted);
-  font-size: 13px;
-}
-.notyet__gap code {
-  font-size: 0.9em;
-}
-.notyet__eta {
-  font-family: var(--font-mono);
-  font-size: 11.5px;
-  font-weight: 600;
-  color: var(--warn);
-  background: rgb(251 191 36 / 0.1);
-  border: 1px solid rgb(251 191 36 / 0.25);
-  padding: 3px 9px;
-  border-radius: 5px;
-  white-space: nowrap;
-  letter-spacing: 0.04em;
-}
-.notyet__foot {
-  margin: 0;
-  font-family: var(--font-mono);
+.ledger__pillar i {
+  display: block;
+  font-style: normal;
   font-size: 12.5px;
   color: var(--fg-dim);
-  position: relative;
+  margin-top: 3px;
 }
-.notyet__foot a {
-  color: var(--accent);
-  transition: color 0.15s;
+.grade {
+  font-family: var(--mono);
+  font-size: 13px;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: flex-start;
+  gap: 6px;
+  line-height: 1.4;
 }
-.notyet__foot a:hover {
-  color: var(--accent-strong);
+.grade--ok {
+  color: var(--ok);
+}
+.grade--warn {
+  color: var(--warn);
+}
+.grade::before {
+  content: "";
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  margin-top: 5px;
+  flex: none;
+}
+.grade--ok::before {
+  background: var(--ok);
+  box-shadow: 0 0 8px rgb(74 222 128 / 0.5);
+}
+.grade--warn::before {
+  background: var(--warn);
+  box-shadow: 0 0 8px rgb(245 177 75 / 0.45);
 }
 
-/* ───── "just shipped" rail — the inverse of the old notyet rail.
-       Same grid + column shape so anyone comparing Wayback snapshots
-       sees we walked the talk. Green accent, ✓ marks, PR refs in
-       place of ETAs. ───── */
-.shipped {
-  margin-top: 32px;
-  background: linear-gradient(180deg, rgb(74 222 128 / 0.05) 0%, rgb(11 14 20 / 0) 100%);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: 28px 32px 24px;
-  position: relative;
-  overflow: hidden;
+.honesty {
+  max-width: 940px;
+  margin: 22px auto 0;
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--accent);
+  border-radius: 12px;
+  padding: 22px 24px;
 }
-.shipped::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background-image: repeating-linear-gradient(
-    135deg,
-    transparent 0 10px,
-    rgb(74 222 128 / 0.03) 10px 11px
-  );
-}
-.shipped__eyebrow {
-  font-family: var(--font-mono);
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--ok);
-  margin: 0 0 18px;
-  position: relative;
-}
-.shipped__list {
-  list-style: none;
-  margin: 0 0 20px;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  position: relative;
-}
-.shipped__item {
-  display: grid;
-  grid-template-columns: 24px 1.4fr 2fr auto;
-  gap: 14px;
-  align-items: baseline;
-  padding: 12px 4px;
-  border-bottom: 1px dashed var(--border);
-  font-size: 13.5px;
-}
-.shipped__item:last-child {
-  border-bottom: none;
-}
-.shipped__mark {
-  font-family: var(--font-mono);
+.honesty__title {
+  font-family: var(--mono);
   font-weight: 700;
-  color: var(--ok);
-  font-size: 15px;
-}
-.shipped__title {
-  font-weight: 600;
-  color: var(--fg);
-}
-.shipped__title code {
-  font-size: 0.9em;
-}
-.shipped__gap {
-  color: var(--fg-muted);
-  font-size: 13px;
-}
-.shipped__gap code {
-  font-size: 0.9em;
-}
-.shipped__pr {
-  font-family: var(--font-mono);
-  font-size: 11.5px;
-  font-weight: 600;
-  color: var(--ok);
-  background: rgb(74 222 128 / 0.1);
-  border: 1px solid rgb(74 222 128 / 0.3);
-  padding: 3px 9px;
-  border-radius: 5px;
-  white-space: nowrap;
-  letter-spacing: 0.04em;
-  transition: background 0.15s, border-color 0.15s;
-}
-.shipped__pr:hover {
-  background: rgb(74 222 128 / 0.18);
-  border-color: rgb(74 222 128 / 0.55);
-}
-.shipped__foot {
-  margin: 0;
-  font-family: var(--font-mono);
-  font-size: 12.5px;
-  color: var(--fg-dim);
-  position: relative;
-}
-.shipped__foot a {
-  color: var(--accent);
-  transition: color 0.15s;
-}
-.shipped__foot a:hover {
-  color: var(--accent-strong);
-}
-.shipped__foot code {
-  font-size: 0.92em;
-}
-
-/* Responsive — matches notyet rail breakpoints exactly. */
-@media (max-width: 1080px) {
-  .shipped__item {
-    grid-template-columns: 20px 1fr auto;
-  }
-  .shipped__gap {
-    grid-column: 2 / 4;
-    grid-row: 2;
-    font-size: 12.5px;
-  }
-}
-@media (max-width: 640px) {
-  .shipped {
-    padding: 22px 20px 18px;
-  }
-  .shipped__item {
-    grid-template-columns: 18px 1fr;
-    row-gap: 4px;
-  }
-  .shipped__gap,
-  .shipped__pr {
-    grid-column: 2;
-  }
-  .shipped__pr {
-    justify-self: start;
-  }
-}
-
-/* ───── final star CTA section ───── */
-.star-cta {
-  padding: 88px 28px 100px;
-  background: radial-gradient(ellipse at 50% 0%, rgb(94 234 212 / 0.12) 0%, transparent 55%),
-    radial-gradient(ellipse at 50% 100%, rgb(147 197 253 / 0.06) 0%, transparent 50%);
-  position: relative;
-  overflow: hidden;
-}
-.star-cta::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background-image: radial-gradient(circle at 50% 30%, rgb(94 234 212 / 0.08) 0%, transparent 30%),
-    radial-gradient(circle at 20% 80%, rgb(94 234 212 / 0.04) 0%, transparent 20%),
-    radial-gradient(circle at 80% 80%, rgb(94 234 212 / 0.04) 0%, transparent 20%);
-  pointer-events: none;
-}
-.star-cta__inner {
-  max-width: 640px;
-  margin: 0 auto;
-  text-align: center;
-  position: relative;
-}
-.star-cta h2 {
-  font-size: clamp(36px, 4.8vw, 56px);
-  margin: 14px 0 18px;
-  letter-spacing: -0.025em;
-}
-.star-cta .lede {
-  max-width: 52ch;
-  margin-left: auto;
-  margin-right: auto;
-}
-.star-cta__actions {
+  font-size: 14px;
+  margin: 0 0 10px;
   display: flex;
-  gap: 14px;
-  justify-content: center;
-  flex-wrap: wrap;
-  margin: 26px 0 16px;
-}
-.star-cta__foot {
-  font-family: var(--font-mono);
-  font-size: 12.5px;
-  color: var(--fg-dim);
-  margin-top: 18px;
-}
-
-/* ───── button variants ───── */
-.btn--compact {
-  padding: 8px 14px;
-  font-size: 13px;
-}
-.btn--large {
-  padding: 16px 28px;
-  font-size: 15.5px;
+  align-items: center;
   gap: 10px;
 }
-.star-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  transition: border-color 0.15s, color 0.15s, background 0.15s, transform 0.15s;
+.honesty p {
+  color: var(--fg-muted);
+  font-size: 14.5px;
+  margin: 0;
 }
-.star-btn:hover {
-  border-color: var(--accent);
-  color: var(--accent);
-  transform: translateY(-1px);
-}
-.star-btn svg {
-  transition: transform 0.2s;
-}
-.star-btn:hover svg {
-  transform: rotate(-10deg) scale(1.1);
+.honesty p b {
+  color: var(--fg);
 }
 
-/* ───── install tab: "then" thin variant ───── */
-.install__then--thin {
-  text-align: center;
-  font-family: var(--font-sans);
-  font-size: 13px;
-  letter-spacing: 0;
-  text-transform: none;
-  color: var(--fg-muted);
-  margin-top: 6px;
+/* ===== VALIDATOR ========================================================= */
+.validator__panes {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
 }
-.install__then--thin a {
+.validator__editor,
+.validator__out {
+  background: var(--bg-1);
+  border: 1px solid var(--line-2);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+.validator__editor-bar,
+.validator__out-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--line);
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--fg-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: rgb(255 255 255 / 0.02);
+}
+#yaml-input {
+  flex: 1;
+  min-height: 340px;
+  resize: vertical;
+  border: 0;
+  outline: none;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--mono);
+  font-size: 12.8px;
+  line-height: 1.65;
+  padding: 16px 18px;
+  tab-size: 2;
+}
+#yaml-input:focus {
+  box-shadow: inset 0 0 0 1px rgb(94 234 212 / 0.4);
+}
+.validator__out-bar .btn {
+  padding: 6px 13px;
+  font-size: 12.5px;
+}
+.findings {
+  list-style: none;
+  margin: 0;
+  padding: 14px;
+  flex: 1;
+  overflow: auto;
+  display: grid;
+  gap: 8px;
+  align-content: start;
+  min-height: 340px;
+}
+.findings__placeholder {
+  color: var(--fg-dim);
+  font-family: var(--mono);
+  font-size: 13px;
+  padding: 10px;
+}
+.finding {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 12px;
+  align-items: start;
+  padding: 11px 13px;
+  border-radius: 9px;
+  background: var(--bg);
+  border: 1px solid var(--line);
+}
+.finding__tag {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 3px 8px;
+  border-radius: 6px;
+  white-space: nowrap;
+}
+.finding--ok {
+  border-color: rgb(74 222 128 / 0.3);
+}
+.finding--ok .finding__tag {
+  background: rgb(74 222 128 / 0.14);
+  color: var(--ok);
+}
+.finding--warn {
+  border-color: rgb(245 177 75 / 0.3);
+}
+.finding--warn .finding__tag {
+  background: rgb(245 177 75 / 0.14);
+  color: var(--warn);
+}
+.finding--error {
+  border-color: rgb(248 113 113 / 0.35);
+}
+.finding--error .finding__tag {
+  background: rgb(248 113 113 / 0.14);
+  color: var(--danger);
+}
+.finding__code {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  color: var(--fg);
+  font-weight: 600;
+}
+.finding__msg {
+  font-size: 13px;
+  color: var(--fg-muted);
+  margin-top: 2px;
+}
+
+/* ===== CTA =============================================================== */
+.cta {
+  text-align: center;
+}
+.cta .sec__label {
   color: var(--accent);
 }
-.install__then--thin a:hover {
-  color: var(--accent-strong);
+.cta h2 {
+  font-family: var(--mono);
+  font-weight: 800;
+  font-size: clamp(24px, 3.4vw, 38px);
+  letter-spacing: -0.02em;
+  margin: 10px auto 0;
+  max-width: 720px;
+  line-height: 1.15;
 }
-.install__block .dim {
+.cta__sub {
+  color: var(--fg-muted);
+  max-width: 600px;
+  margin: 16px auto 30px;
+}
+.cta__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: center;
+}
+
+/* ===== FOOTER ============================================================ */
+.site-footer {
+  border-top: 1px solid var(--line);
+  margin-top: 40px;
+  background: var(--bg-1);
+}
+.site-footer__top {
+  max-width: var(--maxw);
+  margin-inline: auto;
+  padding: 56px clamp(20px, 5vw, 40px) 40px;
+  display: grid;
+  grid-template-columns: 1.4fr 2fr;
+  gap: 40px;
+}
+.site-footer__brand .brand__name {
+  font-family: var(--mono);
+  font-size: 16px;
+}
+.site-footer__brand .brand__alias {
+  margin-left: 8px;
+}
+.site-footer__brand p {
+  color: var(--fg-muted);
+  font-size: 14px;
+  max-width: 360px;
+  margin: 14px 0 0;
+}
+.site-footer__ai {
+  font-size: 13px !important;
+  color: var(--fg-dim) !important;
+}
+.site-footer__cols {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+}
+.site-footer__h {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--fg-dim);
+  margin: 0 0 12px;
+}
+.site-footer__cols a {
+  display: block;
+  color: var(--fg-muted);
+  font-size: 14px;
+  padding: 5px 0;
+}
+.site-footer__cols a:hover {
+  color: var(--accent);
+}
+.site-footer__bar {
+  border-top: 1px solid var(--line);
+  max-width: var(--maxw);
+  margin-inline: auto;
+  padding: 18px clamp(20px, 5vw, 40px);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 20px;
+  justify-content: space-between;
+  font-family: var(--mono);
+  font-size: 12px;
   color: var(--fg-dim);
 }
+.site-footer__bar code {
+  font-size: 11px;
+}
 
-/* ───── entrance animations (respects prefers-reduced-motion) ───── */
-@media (prefers-reduced-motion: no-preference) {
+/* ===== MOTION (fade-in from app.js) ===================================== */
+.fade-in {
+  opacity: 0;
+  transform: translateY(18px);
+  transition: opacity 0.7s ease, transform 0.7s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.fade-in.is-visible {
+  opacity: 1;
+  transform: none;
+}
+@media (prefers-reduced-motion: reduce) {
   .fade-in {
-    opacity: 0;
-    transform: translateY(18px);
-    transition: opacity 0.7s cubic-bezier(0.2, 0.6, 0.2, 1), transform 0.7s
-      cubic-bezier(0.2, 0.6, 0.2, 1);
+    opacity: 1 !important;
+    transform: none !important;
+    transition: none;
   }
-  .fade-in.is-visible {
-    opacity: 1;
-    transform: translateY(0);
+  .terminal__cursor {
+    animation: none;
+  }
+  html {
+    scroll-behavior: auto;
   }
 }
 
-/* ───── responsive ───── */
-@media (max-width: 1080px) {
-  .caps__grid,
-  .lifecycle__grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-  .ent__grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-  .notyet__item {
-    grid-template-columns: 20px 1fr auto;
-  }
-  .notyet__gap {
-    grid-column: 2 / 4;
-    grid-row: 2;
-    font-size: 12.5px;
-  }
-}
-@media (max-width: 960px) {
+/* ===== RESPONSIVE ======================================================== */
+@media (max-width: 940px) {
   .hero {
     grid-template-columns: 1fr;
-    padding: 48px 24px 60px;
-    gap: 40px;
   }
-  .hero h1 br {
-    display: none;
+  .terminal {
+    min-height: 300px;
+    order: 2;
   }
-  .validator__grid {
+  .loop,
+  .caps__grid {
+    grid-template-columns: 1fr 1fr;
+  }
+  .validator__panes {
     grid-template-columns: 1fr;
   }
-  .stat-row {
-    flex-wrap: wrap;
-  }
-  .stat {
-    flex-basis: 50%;
-    border-right: none;
-    border-bottom: 1px solid var(--border);
-  }
-  .stat:nth-child(odd) {
-    border-right: 1px solid var(--border);
-  }
-  .stat:nth-last-child(-n + 2) {
-    border-bottom: none;
+  .site-footer__top {
+    grid-template-columns: 1fr;
+    gap: 32px;
   }
 }
-@media (max-width: 640px) {
-  .site-header {
-    padding: 22px 20px 8px;
-    flex-wrap: wrap;
-    gap: 12px;
-  }
-  .brand__alias {
+@media (max-width: 680px) {
+  .site-nav > a:not(.star-pill) {
     display: none;
   }
-  .site-nav {
-    gap: 18px;
-    width: 100%;
-    justify-content: flex-end;
-  }
-  .site-nav a:not(.star-pill) {
-    display: none;
-  }
-  .site-nav a:not(.star-pill)[href*="docs.declaragent.dev"] {
-    display: inline;
-  }
-  .hero,
-  .meta,
-  .caps,
-  .lifecycle,
-  .ent,
-  .validator,
-  .install,
-  .star-cta {
-    padding-left: 20px;
-    padding-right: 20px;
-  }
+  .loop,
   .caps__grid,
-  .lifecycle__grid,
-  .ent__grid {
+  .site-footer__cols {
     grid-template-columns: 1fr;
   }
-  .meta__inner {
-    padding: 28px 22px 24px;
-  }
-  .meta__flow {
-    flex-direction: column;
-  }
-  .meta__arrow {
-    transform: rotate(90deg);
-    align-self: center;
-    width: 32px;
-  }
-  .site-footer__inner {
+  .ledger__row {
     grid-template-columns: 1fr;
-    text-align: left;
+    gap: 8px;
   }
-  .hero__actions {
-    flex-direction: column;
-    align-items: stretch;
+  .ledger__row--head {
+    display: none;
   }
-  .cmd {
-    justify-content: center;
+  .ledger__pillar {
+    margin-bottom: 2px;
   }
-  .btn {
-    justify-content: center;
+  .grade {
+    font-size: 12.5px;
   }
-  .notyet {
-    padding: 22px 20px 18px;
-  }
-  .notyet__item {
-    grid-template-columns: 18px 1fr;
-    row-gap: 4px;
-  }
-  .notyet__gap,
-  .notyet__eta {
-    grid-column: 2;
-  }
-  .notyet__eta {
-    justify-self: start;
-  }
-  .star-cta {
-    padding-top: 64px;
-    padding-bottom: 72px;
-  }
-  .star-cta__actions {
-    flex-direction: column;
-  }
-  .star-cta__actions .btn {
-    width: 100%;
-  }
-  .pillar__foot {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-  .pillar__foot .receipt-link {
-    margin-left: 0;
+  .hero h1 {
+    font-size: clamp(30px, 9vw, 44px);
   }
 }


### PR DESCRIPTION
Full visual redesign of declaragent.dev (now **live** on Cloudflare Pages production). Dark monospace-forward "audit-ledger / terminal" aesthetic; 10→6 sections; deduplicated capability grids; the ✓/◐/○ status ledger is the centerpiece; `0.7.1`→`0.7.6`; dropped the enterprise/Production/canary overclaims (PROD_parity P2-16). All `app.js` functionality preserved (terminal, install tabs/copy, in-browser validator, PostHog).

Only touches `website/` — brings `main` (source of truth) in sync with the deployed site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)