### PR TITLE
redesign(docs-site): branded landing + audit-ledger theme

### DIFF
--- a/docs-site/docs/intro.mdx
+++ b/docs-site/docs/intro.mdx
@@ -1,57 +1,79 @@
 ---
 id: intro
-title: Declaragent
+title: Declaragent docs
+description: Declarative, git-versioned AI agents. One agent.yaml. git log. Open source.
 slug: /
 sidebar_position: 1
+hide_table_of_contents: true
 ---
 
-# Declaragent
+<div className="dhome">
 
-**An agent for enterprises to build and manage fleets of agents.**
+<div className="dhome__hero">
+  <p className="dhome__kicker"><span className="dhome__sq"></span>open source · apache-2.0 · v0.7.6 on npm</p>
 
-One `agent.yaml` in git describes identity, capabilities, tools, skills, event sources, channels, secrets, and who can call whom. One CLI — `declaragent` — is itself an agent built on `@declaragent/core`, the same runtime you'd ship to production. No second implementation, no vendor dashboard locked out of your repo.
+# Ship an `agent.yaml`, not a prototype.
 
-## The four pillars
+<p className="dhome__sub">
+Declaragent is a declarative, git-versioned runtime for AI agents. One
+<code>agent.yaml</code> in your repo describes identity, tools, skills, channels,
+permissions, secrets and deploy — <strong>no hidden console, no vendor dashboard</strong>.
+<code>git log</code> is the source of truth.
+</p>
 
-1. **Define** agents declaratively — capabilities, skills, inbound + outbound channels, peers to call.
-2. **Deploy + monitor** fleets — one-command rollout, rolling + canary strategies, Prometheus + OpenTelemetry out of the box.
-3. **Independent by default** — each agent owns its session, secrets, and sources. Delegation between agents is explicit via `rpc-peers.yaml`.
-4. **Tools + MCP** — seven built-in tools, full MCP server support (stdio / HTTP / SSE / OAuth PKCE), plugin-contributed extensions.
+```bash
+npm i -g @declaragent/cli
+```
 
-See [FIRST_PRINCIPLES_AUDIT.md](https://github.com/declaragent/declaragent/blob/main/docs/FIRST_PRINCIPLES_AUDIT.md) for an evidence-backed map of intent → code.
-
-## Where to go next
-
-<div className="card-grid">
-
-- **[Quickstart →](/quickstart)** — the 10-minute path. Install, run `declaragent init`, observe it with Prometheus + OTel.
-- **[Reference →](/reference)** — the `agent.yaml` schema, CLI verbs, env vars, provider matrix, extension registry.
-- **[Cookbook →](/cookbook)** — walkthroughs for each template and cross-cutting recipes (multi-agent fleets, deploys, secrets rotation, multi-tenant).
-- **[Troubleshooting →](/troubleshooting)** — error-code reference, install + deploy flowcharts, runbook index.
+<p className="dhome__meta">
+  <span className="dot dot--ok" /> single-machine production-ready ·
+  <span className="dot dot--warn" /> enterprise primitives in preview ·
+  <a href="https://declaragent.dev">declaragent.dev →</a>
+</p>
 
 </div>
 
-## Status
+<div className="card-grid">
+  <a className="dcard" href="/quickstart">
+    <span className="dcard__n">01</span>
+    <h3>Quickstart →</h3>
+    <p>The 10-minute path. Install, <code>declaragent init</code>, run it, watch it with Prometheus + OTel.</p>
+  </a>
+  <a className="dcard" href="/reference">
+    <span className="dcard__n">02</span>
+    <h3>Reference →</h3>
+    <p>The <code>agent.yaml</code> + <code>fleet.yaml</code> schema, every CLI verb, env vars, providers, MCP, RPC, observability.</p>
+  </a>
+  <a className="dcard" href="/cookbook">
+    <span className="dcard__n">03</span>
+    <h3>Cookbook →</h3>
+    <p>Templates and recipes — concierge, PR-review, multi-tenant, GitOps, SIEM export, zero-trust RPC, cross-host fleets.</p>
+  </a>
+  <a className="dcard" href="/troubleshooting">
+    <span className="dcard__n">04</span>
+    <h3>Troubleshooting →</h3>
+    <p>Error-code reference, install + deploy flowcharts, and the operational runbook index.</p>
+  </a>
+</div>
 
-This site tracks **v0.5.21** (latest on npm) with **0.6.0 staged** (eight slices merged; tag + publish gated by operator sign-off — see [RELEASE_0_6_0_READINESS.md](https://github.com/declaragent/declaragent/blob/main/docs/RELEASE_0_6_0_READINESS.md)). See the [changelog](https://github.com/declaragent/declaragent/releases) for the per-release deltas.
+## The five pillars
 
-## What's new in 0.6.0 (staged)
+<div className="dledger">
+  <div className="dledger__row"><span><strong>Define agents</strong> — capabilities, skills, inbound + outbound channels, peers</span><span className="dgrade dgrade--ok">✓ single-machine</span><span className="dgrade dgrade--warn">◐ enterprise</span></div>
+  <div className="dledger__row"><span><strong>Deploy + monitor fleets</strong> — up/down/ps/logs, Prometheus, OpenTelemetry</span><span className="dgrade dgrade--ok">✓ single-machine</span><span className="dgrade dgrade--warn">◐ enterprise</span></div>
+  <div className="dledger__row"><span><strong>Independent agents</strong> — own session + secrets; optional delegation via Kafka/NATS/SQS/AMQP/MQTT RPC</span><span className="dgrade dgrade--ok">✓ single-machine</span><span className="dgrade dgrade--warn">◐ enterprise</span></div>
+  <div className="dledger__row"><span><strong>Tools + MCP</strong> — 8 built-ins, MCP (stdio/HTTP/SSE/OAuth PKCE), npm plugins</span><span className="dgrade dgrade--ok">✓ single-machine</span><span className="dgrade dgrade--warn">◐ enterprise</span></div>
+  <div className="dledger__row"><span><strong>Conversational builder</strong> — describe a fleet in chat, review the plan, <code>git commit</code></span><span className="dgrade dgrade--ok">✓ single-machine</span><span className="dgrade dgrade--warn">◐ enterprise</span></div>
+</div>
 
-- **Prometheus `/metrics` endpoint** _(Slice 1)_ — scrape on `127.0.0.1:9464` when running `declaragent up -d`. Source + channel counters flow through the shared registry automatically.
-- **OpenTelemetry auto-enable** _(Slice 2)_ — set `OTEL_EXPORTER_OTLP_ENDPOINT`, install the peer deps, and `up` wires the bridged tracer into every source + channel. No code changes.
-- **Per-skill circuit breakers** _(Slice 3)_ — 10 consecutive failures trip the breaker, 30-s cooldown, half-open probe re-closes. State + transitions exported as Prometheus counters. `declaragent events list --state circuit-open` filter.
-- **Default provider rate limits** _(Slice 4)_ — token bucket at the LLM call site. Anthropic 50 rps / OpenRouter 20 rps / unknown 10 rps. Env escape hatches for loud-dev workloads.
-- **Dispatch DLQ** _(Slice 5)_ — `rejected_events` table tracks every rejected dispatch; `declaragent dlq list/show/drop --kind dispatch` for audit + acknowledge.
-- **Inbound channels → skills** _(Slice 6)_ — `channels.json#inbound.routes` maps Slack mentions / Telegram DMs / Discord / WhatsApp events to skills with one line of config.
-- **Kafka RPC transport** _(Slice 7)_ — `createKafkaTransport` carries `RequestAgent` envelopes across processes. Nightly integration CI against Redpanda.
-- **Canary fleet deploys** _(Slice 8)_ — `declaragent fleet deploy --canary --canary-wait-ms <n>`: deploy one agent, soak, re-probe, then roll out the rest. Auto-rollback on post-soak failure.
+<div className="dhome__note">
+  <strong>Honest status.</strong> Single-machine production is shipping on npm today.{" "}
+  <strong>Enterprise is ◐, on purpose</strong> — the primitives are built and tested, but
+  not yet soak-proven at scale, third-party pen-tested, or running in anyone's production
+  but the maintainer's. Every grade is backed by a test or a <code>file:line</code> in{" "}
+  <a href="https://github.com/declaragent/declaragent/blob/main/AGENTS.md">AGENTS.md</a>.
+  See the <a href="https://github.com/declaragent/declaragent/releases">changelog</a> for
+  per-release deltas.
+</div>
 
-## What's new in 0.5.x (shipped)
-
-The five runtime-activation slices that unlocked end-to-end 0.6.0 work:
-
-- **External source adapter discovery** _(0.5.0)_ — `declaragent up` now auto-discovers `@declaragent/source-*` packages installed in `node_modules`. Kafka, NATS, SQS, AMQP, MQTT all start when installed.
-- **MCP runtime activation** _(0.5.0–0.5.1)_ — stdio + HTTP + SSE + OAuth PKCE + `@server:resource` references.
-- **Channel runtime + `SendMessage`** _(0.5.0)_ — `up` spins every channel in `channels.json`; skills can call `SendMessage({kind:'channel', …})` without plugin wiring.
-- **Plugin runtime activation** _(0.5.0)_ — consented plugins load at `up` time, contributing tools / skills / commands / hooks.
-- **Non-memory RPC transports + `RequestAgent`** _(0.5.0)_ — `declaragent fleet run` honors every transport kind declared in `capabilities.yaml`; `RequestAgent` is appended to the per-agent tool list when `rpc-peers.yaml` is present.
+</div>

--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -152,7 +152,7 @@ const config: Config = {
       additionalLanguages: ['bash', 'yaml', 'json', 'toml', 'docker'],
     },
     colorMode: {
-      defaultMode: 'light',
+      defaultMode: 'dark',
       respectPrefersColorScheme: true,
     },
   } satisfies Preset.ThemeConfig,

--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -1,29 +1,223 @@
 /**
- * Declaragent docs — theme overrides.
- * Keep this file small; most colors use Docusaurus' Infima defaults.
+ * Declaragent docs — "audit-ledger / terminal" theme to match declaragent.dev.
+ * Teal signature, JetBrains Mono headings + Inter body, ✓/◐/○ status system.
  */
 
+@import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700;800&family=Inter:wght@400;500;600;700&display=swap");
+
 :root {
-  --ifm-color-primary: #2563eb;
-  --ifm-color-primary-dark: #1d4ed8;
-  --ifm-color-primary-darker: #1e40af;
-  --ifm-color-primary-darkest: #1e3a8a;
-  --ifm-color-primary-light: #3b82f6;
-  --ifm-color-primary-lighter: #60a5fa;
-  --ifm-color-primary-lightest: #93c5fd;
-  --ifm-code-font-size: 92%;
-  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+  --ifm-color-primary: #0d9488;
+  --ifm-color-primary-dark: #0c8278;
+  --ifm-color-primary-darker: #0b7a70;
+  --ifm-color-primary-darkest: #09645c;
+  --ifm-color-primary-light: #14b8a6;
+  --ifm-color-primary-lighter: #2dd4bf;
+  --ifm-color-primary-lightest: #5eead4;
+  --ifm-font-family-base: "Inter", ui-sans-serif, system-ui, sans-serif;
+  --ifm-font-family-monospace: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  --ifm-heading-font-family: "JetBrains Mono", ui-monospace, monospace;
+  --ifm-heading-font-weight: 700;
+  --ifm-code-font-size: 90%;
+  --ifm-navbar-background-color: rgba(255, 255, 255, 0.85);
+  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.08);
+
+  --dg-ok: #16a34a;
+  --dg-warn: #d97706;
 }
 
 [data-theme="dark"] {
-  --ifm-color-primary: #60a5fa;
-  --ifm-color-primary-dark: #3b82f6;
-  --ifm-color-primary-darker: #2563eb;
-  --ifm-color-primary-darkest: #1d4ed8;
-  --ifm-color-primary-light: #93c5fd;
-  --ifm-color-primary-lighter: #bfdbfe;
-  --ifm-color-primary-lightest: #dbeafe;
-  --docusaurus-highlighted-code-line-bg: rgba(255, 255, 255, 0.1);
+  --ifm-color-primary: #5eead4;
+  --ifm-color-primary-dark: #2dd4bf;
+  --ifm-color-primary-darker: #14b8a6;
+  --ifm-color-primary-darkest: #0d9488;
+  --ifm-color-primary-light: #99f6e4;
+  --ifm-color-primary-lighter: #ccfbf1;
+  --ifm-color-primary-lightest: #f0fdfa;
+  --ifm-background-color: #090b10;
+  --ifm-background-surface-color: #0d1018;
+  --ifm-navbar-background-color: rgba(9, 11, 16, 0.8);
+  --ifm-footer-background-color: #0b0e14;
+  --ifm-toc-border-color: #222a39;
+  --ifm-color-emphasis-200: #222a39;
+  --ifm-color-emphasis-300: #2f3950;
+  --docusaurus-highlighted-code-line-bg: rgba(94, 234, 212, 0.1);
+
+  --dg-ok: #4ade80;
+  --dg-warn: #f5b14b;
+}
+
+h1,
+h2,
+h3 {
+  letter-spacing: -0.02em;
+}
+
+[data-theme="dark"] .navbar {
+  border-bottom: 1px solid #222a39;
+  backdrop-filter: blur(12px);
+}
+.navbar__title {
+  font-family: var(--ifm-font-family-monospace);
+  font-weight: 700;
+}
+
+/* ===== Landing page (intro.mdx slug:/) ================================== */
+.dhome {
+  max-width: 980px;
+  margin: 0 auto;
+}
+.dhome__hero {
+  padding: 1.5rem 0 2.5rem;
+  border-bottom: 1px solid var(--ifm-toc-border-color, #e3e8ef);
+  margin-bottom: 2.5rem;
+}
+.dhome__kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.78rem;
+  color: var(--ifm-color-emphasis-700);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 999px;
+  padding: 0.3rem 0.8rem;
+  margin: 0 0 1.2rem;
+}
+.dhome__sq {
+  width: 7px;
+  height: 7px;
+  border-radius: 2px;
+  background: var(--ifm-color-primary);
+  box-shadow: 0 0 8px var(--ifm-color-primary);
+}
+.dhome__hero h1 {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: clamp(2rem, 5vw, 3.1rem);
+  line-height: 1.08;
+  margin: 0 0 1rem;
+  font-weight: 800;
+}
+.dhome__hero h1 code {
+  background: none;
+  border: none;
+  color: var(--ifm-color-primary);
+  padding: 0;
+  font-size: inherit;
+}
+.dhome__sub {
+  font-size: 1.1rem;
+  color: var(--ifm-color-emphasis-800);
+  max-width: 38rem;
+  margin-bottom: 1.4rem;
+}
+.dhome__hero pre {
+  max-width: 24rem;
+}
+.dhome__meta {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.82rem;
+  color: var(--ifm-color-emphasis-700);
+  margin-top: 1rem;
+}
+
+.dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  vertical-align: middle;
+  margin-right: 0.15rem;
+}
+.dot--ok {
+  background: var(--dg-ok);
+}
+.dot--warn {
+  background: var(--dg-warn);
+}
+
+/* card grid */
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+  margin: 1.5rem 0 0;
+}
+.dcard {
+  display: block;
+  padding: 1.4rem 1.3rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 14px;
+  background: var(--ifm-background-surface-color);
+  text-decoration: none !important;
+  color: inherit;
+  transition: border-color 0.2s, transform 0.2s, box-shadow 0.2s;
+}
+.dcard:hover {
+  border-color: var(--ifm-color-primary);
+  transform: translateY(-3px);
+  box-shadow: 0 10px 30px -12px rgba(45, 212, 191, 0.3);
+}
+.dcard__n {
+  font-family: var(--ifm-font-family-monospace);
+  font-weight: 800;
+  font-size: 0.8rem;
+  color: var(--ifm-color-primary);
+  border: 1px solid var(--ifm-color-primary);
+  border-radius: 6px;
+  padding: 0.1rem 0.45rem;
+}
+.dcard h3 {
+  font-family: var(--ifm-font-family-monospace);
+  margin: 0.7rem 0 0.4rem;
+  font-size: 1.1rem;
+}
+.dcard p {
+  margin: 0;
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.92rem;
+}
+
+/* status ledger */
+.dledger {
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 14px;
+  overflow: hidden;
+  background: var(--ifm-background-surface-color);
+}
+.dledger__row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 0.8rem 1.2rem;
+  align-items: center;
+  padding: 0.85rem 1.2rem;
+  border-top: 1px solid var(--ifm-color-emphasis-200);
+  font-size: 0.92rem;
+}
+.dledger__row:first-child {
+  border-top: 0;
+}
+.dgrade {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.8rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+.dgrade--ok {
+  color: var(--dg-ok);
+}
+.dgrade--warn {
+  color: var(--dg-warn);
+}
+
+.dhome__note {
+  margin-top: 1.5rem;
+  padding: 1.1rem 1.3rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-left: 3px solid var(--ifm-color-primary);
+  border-radius: 12px;
+  background: var(--ifm-background-surface-color);
+  font-size: 0.92rem;
+  color: var(--ifm-color-emphasis-800);
 }
 
 .todo-block {
@@ -32,4 +226,17 @@
   border-left: 4px solid var(--ifm-color-warning);
   background: rgba(255, 196, 0, 0.08);
   font-size: 0.95em;
+}
+
+@media (max-width: 720px) {
+  .card-grid {
+    grid-template-columns: 1fr;
+  }
+  .dledger__row {
+    grid-template-columns: 1fr;
+    gap: 0.3rem;
+  }
+  .dgrade {
+    font-size: 0.75rem;
+  }
 }


### PR DESCRIPTION
Rebuilds docs.declaragent.dev home + theme to match declaragent.dev (now **live** on the declaragent-docs project). Honest current content (v0.7.6, five pillars, 8 tools), drops stale v0.5.21 / enterprise overclaim; teal + JetBrains Mono + dark-default theme. Only touches `docs-site/`. 🤖 Generated with [Claude Code](https://claude.com/claude-code)